### PR TITLE
Add API routes

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from fastapi import FastAPI
+from sqlalchemy import select
+from sqlalchemy.orm import Session, subqueryload
+
+from . import database
+from .dynamic_routes import create_dynamic_router
+from .models import Schema, AttributeDefinition
+from .general_routes import router
+
+
+def load_schemas() -> List[models.Schema]:
+    try:
+        db: Session = database.SessionLocal()
+        schemas = db.execute(
+            select(Schema)
+            .options(
+                subqueryload(Schema.attr_defs)
+                .subqueryload(AttributeDefinition.attribute)
+            )
+        ).scalars().all()
+        return schemas
+    finally:
+        db.close()
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    schemas = load_schemas()
+    for schema in schemas:
+        create_dynamic_router(schema=schema, app=app, get_db=database.get_db)
+    app.include_router(router)
+    return app

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -354,8 +354,10 @@ def _parse_filters(filters: dict, attrs: List[str]) -> Tuple[Dict[str, Dict[str,
         if attr == 'name':
             name_filters[filter] = v
             continue
-        elif attr not in attrs or filter not in FILTER_MAP:
-            continue
+        elif attr not in attrs:
+            raise InvalidFilterAttributeException(attr=attr, allowed_attrs=attrs)
+        elif filter not in FILTER_MAP:
+            raise InvalidFilterOperatorException(attr=attr, filter=filter)
         attrs_filters[attr][FILTER_MAP[filter]] = v
     
     name_filters = {k: v for k,v in name_filters.items() if k in FILTER_MAP and k in ALLOWED_FILTERS[AttrType.STR]}
@@ -367,7 +369,7 @@ def _query_entity_with_filters(filters: dict, schema: Schema, all: bool = False,
     to get entities that satisfy all conditions from `filters`
     '''
     
-    attrs = {i.attribute.name: i.attribute for i in schema.attr_defs}
+    attrs = {i.attribute.name: i.attribute for i in schema.attr_defs if not i.list and i.attribute.type in ALLOWED_FILTERS}
     attrs_filters, name_filters = _parse_filters(filters=filters, attrs=list(attrs))
     selects = []
 

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -2,7 +2,7 @@ from typing import Callable, Dict, List, Tuple, Union
 from collections import defaultdict
 
 import sqlalchemy
-from sqlalchemy import func
+from sqlalchemy import func, distinct
 from sqlalchemy.orm import Session
 from sqlalchemy import select, update
 from sqlalchemy.sql.expression import delete, intersect
@@ -413,7 +413,7 @@ def get_entities(
         q = select(Entity).where(Entity.schema_id == schema.id)
         if not all:
             q = q.where(Entity.deleted == deleted_only)
-    total = db.execute(select(func.count('id')).select_from(q.subquery())).scalar()
+    total = db.execute(select(func.count(distinct(column('id')))).select_from(q.subquery())).scalar()
     q = q.offset(offset).limit(limit).order_by(Entity.id)
     entities = db.execute(select(Entity).from_statement(q)).scalars().all()
 

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -66,12 +66,8 @@ def create_attribute(db: Session, data: AttributeCreateSchema, commit: bool = Tr
 
 def get_schemas(db: Session, all: bool = False, deleted_only: bool = False) -> List[Schema]:
     q = select(Schema)
-    if all:
-        pass
-    elif deleted_only:
-        q = q.where(Schema.deleted == True)
-    else:
-        q = q.where(Schema.deleted == False)
+    if not all:
+        q = q.where(Schema.deleted == deleted_only)
     return db.execute(q).scalars().all()
 
 
@@ -329,7 +325,7 @@ def _get_attr_values_batch(db: Session, entities: List[Entity], attrs_to_include
 
 FILTER_MAP = {
     'eq': '__eq__',
-    'lt':'__lt__',
+    'lt': '__lt__',
     'gt': '__gt__',
     'le': '__le__',
     'ge': '__ge__',
@@ -352,8 +348,8 @@ def _parse_filters(filters: dict, attrs: List[str]) -> Tuple[Dict[str, Dict[str,
     attrs_filters = defaultdict(dict)
     name_filters = {}
     for f, v in filters.items():
-        split = f.split('.')
-        attr = '.'.join(split[:-1]) if len(split) > 1 else split[0]
+        split = f.rsplit('.', maxsplit=1)
+        attr = split[0]
         filter = 'eq' if len(split) == 1 else split[-1]
         if attr == 'name':
             name_filters[filter] = v

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -2,7 +2,7 @@ from typing import Callable, Dict, List, Tuple, Union
 from collections import defaultdict
 
 import sqlalchemy
-from sqlalchemy import func, distinct
+from sqlalchemy import func, distinct, column
 from sqlalchemy.orm import Session
 from sqlalchemy import select, update
 from sqlalchemy.sql.expression import delete, intersect
@@ -371,7 +371,7 @@ def _query_entity_with_filters(filters: dict, schema: Schema, all: bool = False,
     to get entities that satisfy all conditions from `filters`
     '''
     
-    attrs = {i.attribute.name: i.attribute for i in schema.attr_defs if not i.list and i.attribute.type in ALLOWED_FILTERS}
+    attrs = {i.attribute.name: i.attribute for i in schema.attr_defs if i.attribute.type in ALLOWED_FILTERS}
     attrs_filters, name_filters = _parse_filters(filters=filters, attrs=list(attrs))
     selects = []
 

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -268,12 +268,8 @@ def get_entities(
     ) -> List[dict]:
     
     q = select(Entity).where(Entity.schema_id == schema.id)
-    if all:
-        pass
-    elif deleted_only:
-        q = q.where(Entity.deleted == True)
-    else:
-        q = q.where(Entity.deleted == False)
+    if not all:
+        q = q.where(Entity.deleted == deleted_only)
     entities = db.execute(q.offset(offset).limit(limit)).scalars().all()
 
     attr_defs = schema.attr_defs if all_fields else [i for i in schema.attr_defs if i.key]

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,8 +1,8 @@
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import sqlalchemy
 from sqlalchemy.orm import Session
-from sqlalchemy import select, update, func
+from sqlalchemy import select, update
 
 from .models import (
     AttrType,
@@ -24,7 +24,24 @@ from .schemas import (
 from .exceptions import *
 
 
+RESERVED_ATTR_NAMES = ['id', 'name', 'deleted']
+
+
+def get_attributes(db: Session) -> List[Attribute]:
+    return db.execute(select(Attribute)).scalars().all()
+
+
+def get_attribute(db: Session, attr_id: int) -> Attribute:
+    attr = db.execute(select(Attribute).where(Attribute.id == attr_id)).scalar()
+    if attr is None:
+        raise MissingAttributeException(obj_id=attr_id)
+    return attr
+
+
 def create_attribute(db: Session, data: AttributeCreateSchema, commit: bool = True) -> Attribute:
+    if data.name in RESERVED_ATTR_NAMES:
+        raise ReservedAttributeException(attr_name=data.name, reserved=RESERVED_ATTR_NAMES)
+
     attr = db.execute(
         select(Attribute)
         .where(Attribute.name == data.name)
@@ -38,6 +55,30 @@ def create_attribute(db: Session, data: AttributeCreateSchema, commit: bool = Tr
     if commit:
         db.commit()  # This may raise IntegrityError if other session commits same data
     return a
+
+
+def get_schemas(db: Session, all: bool = False, deleted_only: bool = False) -> List[Schema]:
+    q = select(Schema)
+    if all:
+        pass
+    elif deleted_only:
+        q = q.where(Schema.deleted == True)
+    else:
+        q = q.where(Schema.deleted == False)
+    return db.execute(q).scalars().all()
+
+
+def get_schema(db: Session, id_or_slug: Union[int, str]) -> Schema:
+    q = select(Schema)
+    if isinstance(id_or_slug, int):
+        q = q.where(Schema.id == id_or_slug)
+    else:
+        q = q.where(Schema.slug == id_or_slug)
+        
+    schema = db.execute(q).scalar()
+    if schema is None:
+        raise MissingSchemaException(obj_id=id_or_slug)
+    return schema
 
 
 def create_schema(db: Session, data: SchemaCreateSchema) -> Schema:
@@ -203,7 +244,55 @@ def update_schema(db: Session, schema_id: int, data: SchemaUpdateSchema) -> Sche
         db.rollback()
         raise SchemaExistsException(name=data.name, slug=data.slug)
     return sch
-        
+
+
+def _get_entity_data(db: Session, entity: Entity, attr_names: List[str]) -> Dict[str, Any]:
+    data = {'id': entity.id, 'name': entity.name, 'deleted': entity.deleted}
+    for attr in attr_names:
+        val_obj = entity.get(attr, db)
+        try:
+            data[attr] = val_obj.value if not isinstance(val_obj, list) else [i.value for i in val_obj]   
+        except AttributeError:
+            data[attr] = None
+    return data
+
+
+def get_entities(
+        db: Session, 
+        schema: Schema,
+        limit: int = None,
+        offset: int = None,
+        all: bool = False, 
+        deleted_only: bool = False, 
+        all_fields: bool = False
+    ) -> List[dict]:
+    
+    q = select(Entity).where(Entity.schema_id == schema.id)
+    if all:
+        pass
+    elif deleted_only:
+        q = q.where(Entity.deleted == True)
+    else:
+        q = q.where(Entity.deleted == False)
+    entities = db.execute(q.offset(offset).limit(limit)).scalars().all()
+
+    attr_defs = schema.attr_defs if all_fields else [i for i in schema.attr_defs if i.key]
+    data = []
+    for e in entities:
+        data.append(_get_entity_data(db, entity=e, attr_names=[i.attribute.name for i in attr_defs]))
+    return data
+
+
+def get_entity(db: Session, entity_id: int, schema: Schema) -> dict:
+    e = db.execute(select(Entity).where(Entity.id == entity_id)).scalar()
+    if e is None:
+        raise MissingEntityException(obj_id=entity_id)
+    if e.schema_id != schema.id:
+        raise MismatchingSchemaException(entity_id=entity_id, schema_id=schema.id)
+
+    attrs = [i.attribute.name for i in schema.attr_defs]
+    return _get_entity_data(db=db, entity=e, attr_names=attrs)
+
         
 def create_entity(db: Session, schema_id: int, data: dict) -> Entity:
     sch: Schema = db.execute(

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -329,11 +329,13 @@ FILTER_MAP = {
     'gt': '__gt__',
     'le': '__le__',
     'ge': '__ge__',
-    'ne': '__ne__'
+    'ne': '__ne__',
+    'contains': 'contains',
+    'regexp': 'regexp_match'
 }
 
 ALLOWED_FILTERS = {
-    AttrType.STR: ['eq', 'lt', 'gt', 'le', 'ge', 'ne'],
+    AttrType.STR: ['eq', 'lt', 'gt', 'le', 'ge', 'ne', 'contains', 'regexp_match'],
     AttrType.INT: ['eq', 'lt', 'gt', 'le', 'ge', 'ne'],
     AttrType.FLOAT: ['eq', 'lt', 'gt', 'le', 'ge', 'ne'],
     AttrType.DT: ['eq', 'lt', 'gt', 'le', 'ge', 'ne'],

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -27,6 +27,7 @@ from .exceptions import *
 
 
 RESERVED_ATTR_NAMES = ['id', 'slug', 'deleted', 'name']
+RESERVED_SCHEMA_SLUGS = ['schemas', 'attributes']
 
 
 def get_attributes(db: Session) -> List[Attribute]:
@@ -84,6 +85,8 @@ def get_schema(db: Session, id_or_slug: Union[int, str]) -> Schema:
 
 
 def create_schema(db: Session, data: SchemaCreateSchema) -> Schema:
+    if data.slug in RESERVED_SCHEMA_SLUGS:
+        raise ReservedSchemaSlugException(slug=data.slug, reserved=RESERVED_SCHEMA_SLUGS)
     try:
         sch = Schema(name=data.name, slug=data.slug)
         db.add(sch)
@@ -158,6 +161,9 @@ def delete_schema(db: Session, schema_id: int) -> Schema:
 
 
 def update_schema(db: Session, id_or_slug: Union[int, str], data: SchemaUpdateSchema) -> Schema:
+    if data.slug in RESERVED_SCHEMA_SLUGS:
+        raise ReservedSchemaSlugException(slug=data.slug, reserved=RESERVED_SCHEMA_SLUGS)
+    
     q = select(Schema).where(Schema.deleted == False)
     if isinstance(id_or_slug, int):
         q = q.where(Schema.id == id_or_slug)

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -335,7 +335,7 @@ FILTER_MAP = {
 }
 
 ALLOWED_FILTERS = {
-    AttrType.STR: ['eq', 'lt', 'gt', 'le', 'ge', 'ne', 'contains', 'regexp_match'],
+    AttrType.STR: ['eq', 'lt', 'gt', 'le', 'ge', 'ne', 'contains', 'regexp'],
     AttrType.INT: ['eq', 'lt', 'gt', 'le', 'ge', 'ne'],
     AttrType.FLOAT: ['eq', 'lt', 'gt', 'le', 'ge', 'ne'],
     AttrType.DT: ['eq', 'lt', 'gt', 'le', 'ge', 'ne'],

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -207,6 +207,9 @@ def update_schema(db: Session, schema_id: int, data: SchemaUpdateSchema) -> Sche
         
         if a.name in attr_names:
             raise MultipleAttributeOccurencesException(attr_name=a.name)
+        elif a.name in attr_def_names:
+            raise AttributeAlreadyDefinedException(attr_id=a.id, schema_id=sch.id)
+
         attr_names.add(a.name)
         
         try:

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -456,14 +456,15 @@ def update_entity(db: Session, id_or_slug: Union[str, int], schema_id: int, data
     return e
 
 
-def delete_entity(db: Session, entity_id: int) -> Entity:
-    e = db.execute(
-        select(Entity)
-        .where(Entity.id == entity_id)
-        .where(Entity.deleted == False)
-    ).scalar()
+def delete_entity(db: Session, id_or_slug: Union[int, str], schema_id: int) -> Entity:
+    q = select(Entity).where(Entity.deleted == False).where(Entity.schema_id == schema_id)
+    if isinstance(id_or_slug, int):
+        q = q.where(Entity.id == id_or_slug)
+    else:
+        q = q.where(Entity.slug == id_or_slug)
+    e = db.execute(q).scalar()
     if e is None:
-        raise MissingEntityException(obj_id=entity_id)
+        raise MissingEntityException(obj_id=id_or_slug)
     e.deleted = True
     db.commit()
     return e

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -16,6 +16,7 @@ from .models import (
 from .schemas import (
     AttrDefSchema,
     AttrDefWithAttrDataSchema,
+    AttributeDefinitionUpdateSchema,
     SchemaCreateSchema,
     SchemaUpdateSchema,
     AttributeCreateSchema
@@ -131,10 +132,15 @@ def update_schema(db: Session, schema_id: int, data: SchemaUpdateSchema) -> Sche
         raise SchemaExistsException(name=data.name, slug=data.slug)
 
     attr_def_ids: Dict[int, AttributeDefinition] = {i.id: i for i in sch.attr_defs}
+    attr_def_names: Dict[str, AttributeDefinition] = {i.attribute.name: i for i in sch.attr_defs}
     for attr in data.update_attributes:
-        attr_def = attr_def_ids.get(attr.id)
+        if isinstance(attr, AttributeDefinitionUpdateSchema):
+            attr_def = attr_def_ids.get(attr.attr_def_id)
+        else:
+            attr_def = attr_def_names.get(attr.name)
+        
         if attr_def is None:
-            raise AttributeNotDefinedException(attr_id=attr.id, schema_id=sch.id)
+            raise AttributeNotDefinedException(attr_id=attr.attr_def_id, schema_id=sch.id)
         if attr_def.list and not attr.list:
             raise ListedToUnlistedException(attr_def_id=attr_def.id)
         if attr.list:

--- a/backend/database.py
+++ b/backend/database.py
@@ -9,3 +9,12 @@ SQLALCHEMY_DATABASE_URL = f"postgresql+psycopg2://{s.pg_user}:{s.pg_password}@{s
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+
+
+def get_db():
+    '''Database dependency for FastAPI'''
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -303,7 +303,7 @@ def route_update_entity(router: APIRouter, schema: Schema, get_db: Callable):
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e)) 
 
 
-def create_dynamic_router(schema: Schema, app: FastAPI, get_db: Callable):
+def create_dynamic_router(schema: Schema, app: FastAPI, get_db: Callable, old_slug: str = None):
     router = APIRouter()
     
     route_get_entity(router=router, schema=schema, get_db=get_db)
@@ -315,6 +315,8 @@ def create_dynamic_router(schema: Schema, app: FastAPI, get_db: Callable):
     routes_to_remove = []
     for route in app.routes:
         if (route.path, route.methods) in router_routes:
+            routes_to_remove.append(route)
+        elif old_slug and (route.path.startswith(f'/{old_slug}/') or route.path == f'/{old_slug}'):
             routes_to_remove.append(route)
     for route in routes_to_remove:
         app.routes.remove(route)

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -311,5 +311,13 @@ def create_dynamic_router(schema: Schema, app: FastAPI, get_db: Callable):
     route_create_entity(router=router, schema=schema, get_db=get_db)
     route_update_entity(router=router, schema=schema, get_db=get_db)
 
+    router_routes = [(r.path, r.methods) for r in router.routes]
+    routes_to_remove = []
+    for route in app.routes:
+        if (route.path, route.methods) in router_routes:
+            routes_to_remove.append(route)
+    for route in routes_to_remove:
+        app.routes.remove(route)
+
     app.include_router(router, prefix='')
     app.openapi_schema = None

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -115,6 +115,18 @@ def _description_for_get_entities(schema: Schema) -> str:
     return description
 
 
+FILTER_DESCRIPTION = {
+    'eq': 'equal to',
+    'lt': 'less than',
+    'gt': 'greater than',
+    'le': 'less than or equal to',
+    'ge': 'greater than or equal to',
+    'ne': 'not equal to',
+    'contains': 'contains substring',
+    'regexp': 'matches regular expression'
+}
+
+
 def _filters_request_model(schema: Schema):
     '''Creates a dataclass that will be used to
     capture filters like `<attr_name>.<operator>=<value>`
@@ -122,9 +134,9 @@ def _filters_request_model(schema: Schema):
     '''
     fields = []
 
-    fields.append(('name', Optional[str], Query(None)))
+    fields.append(('name', Optional[str], Query(None, description=FILTER_DESCRIPTION['eq'])))
     for filter in crud.ALLOWED_FILTERS[AttrType.STR]:
-        fields.append((f'name_{filter}', Optional[str], Query(None, alias=f'name.{filter}')))
+        fields.append((f'name_{filter}', Optional[str], Query(None, alias=f'name.{filter}', description=FILTER_DESCRIPTION[filter])))
 
     for attr_def in schema.attr_defs:
         attr = attr_def.attribute
@@ -135,9 +147,9 @@ def _filters_request_model(schema: Schema):
             .value.model  # AttrType.value -> Mapping, Mapping.model -> Value model
             .value.property.columns[0].type.python_type)  # get python type of value column in Value child
         # default filter {attr.name} which works as {attr.name}.eq, i.e. for equality filtering
-        fields.append((attr.name, Optional[type_], Query(None, alias=attr.name)))
+        fields.append((attr.name, Optional[type_], Query(None, alias=attr.name, description=FILTER_DESCRIPTION['eq'])))
         for filter in crud.ALLOWED_FILTERS[attr.type]:
-            fields.append((f'{attr.name}_{filter}', Optional[type_], Query(None, alias=f'{attr.name}.{filter}')))
+            fields.append((f'{attr.name}_{filter}', Optional[type_], Query(None, alias=f'{attr.name}.{filter}', description=FILTER_DESCRIPTION[filter])))
 
     filter_model = make_dataclass(f"{schema.slug.capitalize().replace('-', '_')}Filters", fields=fields)
     return filter_model

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -1,71 +1,306 @@
-from typing import List, Callable
+from typing import List, Callable, Optional, Union
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from fastapi.applications import FastAPI
 from sqlalchemy.orm.session import Session
+from pydantic import create_model, Field, validator
+from pydantic.main import ModelMetaclass
 
-from .models import Schema
-from . import crud, exceptions
+from .models import Schema, AttributeDefinition
+from . import crud, exceptions, schemas
+
+
+def _make_type(attr_def: AttributeDefinition, optional: bool = False) -> tuple:
+    '''Given `AttributeDefinition` returns a type that will be for type annotations in Pydantic model'''
+    
+    type_ = (attr_def.attribute.type  # AttributeDefinition.Attribute.type -> AttrType
+            .value.model  # AttrType.value -> Mapping, Mapping.model -> Value model
+            .value.property.columns[0].type.python_type)  # get python type of value column in Value child
+    if attr_def.list:
+        type_ = List[type_]
+    if not attr_def.required or optional:
+        type_ = Optional[type_]
+    return (type_, Field(description=attr_def.description))
+
+
+def _get_entity_request_model(schema: Schema, name: str) -> ModelMetaclass:
+    '''
+    Creates Pydantic entity get model
+
+    Model includes all entity attributes, which are all marked as `Optional`,
+    and their descriptions, if defined in `AttributeDefinition`.
+    Also includes fields `id`, `slug` and `deleted`.
+
+    Why attributes are `Optional`: currently, if we add new requried
+    field to schema, which already holds some entities, values for this
+    field in these entities will be `None` and if we don't mark fields
+    as `Optional`, Pydantic will raise exception after receiving `None`
+    for required field.
+
+    So make it clear, which fields are not `Optional` and expected to be
+    in response in any case, it is advised to provide documentation
+    in API that will list all fields and mark them as required/optional.
+    '''
+    field_names = [i.attribute.name for i in schema.attr_defs]
+    types = [_make_type(i, optional=True) for i in schema.attr_defs]
+    fields_types = dict(zip(field_names, types))
+
+    default_fields = {
+        'id': (int, Field(description='ID of this entity')),
+        'deleted': (bool, Field(description='Indicates whether this entity is marked as deleted')),
+        'slug': (str, Field(description='Slug for this entity'))
+    }
+    model = create_model(
+        name,
+        **fields_types,
+        **default_fields
+    )
+    return model
+
+
+def _description_for_get_entity(schema: Schema) -> str:
+    description = 'Returns data for all attributes of entity plus fields `id`, `deleted` and `slug`'
+    
+    fields = [(i.attribute.name, i.required, i.key) for i in schema.attr_defs]
+    description += '\n\nFields:'
+    for name, expected, key in fields:
+        description += f'\n* `{name}` {"" if expected else "(optional)"} {"(key)" if key else ""}'
+    return description
 
 
 def route_get_entity(router: APIRouter, schema: Schema, get_db: Callable):
+    entity_get_schema = _get_entity_request_model(schema=schema, name=f"{schema.slug.capitalize().replace('-', '_')}Get") 
+    description = _description_for_get_entity(schema=schema)
+
     @router.get(
-        f'/{schema.slug}/{{entity_id}}',
+        f'/{schema.slug}/{{id_or_slug}}',
+        response_model=entity_get_schema,
+        tags=[schema.name],
+        summary=f'Get {schema.name} entity by ID',
+        description=description,
+        responses={
+            404: {
+                'description': "Entity with provided ID doesn't exist",
+            },
+            409: {
+                'description': "Entity with provided ID doesn't belong to current schema"
+            }
+        }
     )
-    def get_entity(entity_id: int, db: Session = Depends(get_db)):
+    def get_entity(id_or_slug: Union[int, str], db: Session = Depends(get_db)):
         try:
-            return crud.get_entity(db=db, entity_id=entity_id, schema=schema)
+            return crud.get_entity(db=db, id_or_slug=id_or_slug, schema=schema)
         except exceptions.MissingEntityException as e:
             raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
-        
+        except exceptions.MismatchingSchemaException as e:
+            raise HTTPException(status.HTTP_409_CONFLICT, str(e))
+
+
+def _description_for_get_entities(schema: Schema) -> str:
+    description = 'Lists entities from schema. By default returns *all not deleted* entities with data *only for key fields*'
+    key_fields = [(i.attribute.name, i.required) for i in schema.attr_defs if i.key]
+    key_fields_description = '\n\nKey fields:'
+    for name, expected in key_fields:
+        key_fields_description += f'\n* `{name}` {"" if expected else "(optional)"}'
+    
+    other_fields = [(i.attribute.name, i.required) for i in schema.attr_defs if not i.key]
+    other_fields_description = '\n\nOther fields:'
+    for name, expected in other_fields:
+        other_fields_description += f'\n* `{name}` {"" if expected else "(optional)"}'
+    
+    description += key_fields_description
+    description += other_fields_description
+    return description
+
 
 def route_get_entities(router: APIRouter, schema: Schema, get_db: Callable):
+    entity_schema = _get_entity_request_model(schema=schema, name=f"{schema.slug.capitalize().replace('-', '_')}ListItem")
+    description = _description_for_get_entities(schema=schema)
+
     @router.get(
-        f'/{schema.slug}'
+        f'/{schema.slug}',
+        response_model=List[entity_schema],
+        tags=[schema.name],
+        summary=f'List {schema.name} entities',
+        description=description,
+        response_model_exclude_unset=True
     )
     def get_entities(
-            limit: int = None, 
-            offset: int = None, 
-            all: bool = False, 
-            deleted_only: bool = False, 
-            all_fields: bool = False, 
-            db: Session = Depends(get_db)
-        ):
-        try:
-            return crud.get_entities(
-                db=db, 
-                schema=schema,
-                limit=limit,
-                offset=offset,
-                all=all,
-                deleted_only=deleted_only,
-                all_fields=all_fields
-            )
-        except exceptions.MissingSchemaException as e:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        limit: int = Query(None, min=0, description='Limit results to `limit` entities'), 
+        offset: int = Query(None, min=0, description='Take an offset of `offset` when retreiving entities'), 
+        all: bool = Query(False, description='If true, returns both deleted and not deleted entities'), 
+        deleted_only: bool = Query(False, description='If true, returns only deleted entities. *Note:* if `all` is true `deleted_only` is not checked'), 
+        all_fields: bool = Query(False, description='If true, returns data for all entity fields, not just key ones'), 
+        db: Session = Depends(get_db)
+    ):
+        return crud.get_entities(
+            db=db, 
+            schema=schema,
+            limit=limit,
+            offset=offset,
+            all=all,
+            deleted_only=deleted_only,
+            all_fields=all_fields
+        )
+       
+
+def _create_entity_request_model(schema: Schema) -> ModelMetaclass:
+    '''
+    Creates Pydantic entity create model
+
+    Model includes all entity attributes, which are marked as `Optional`
+    if defined so in `AttributeDefinition`,
+    plus required `slug` field with custom validator for it.
+
+    This model will raise exception if passed fields that don't
+    belong to it.
+    '''
+    field_names = [i.attribute.name for i in schema.attr_defs]
+    types = [_make_type(i) for i in schema.attr_defs]
+    fields_types = dict(zip(field_names, types))
+    
+    class Config:
+        extra = 'forbid'
+
+    model = create_model(
+        f"{schema.slug.capitalize().replace('-', '_')}Create",
+        **fields_types,
+        slug=(str, Field(description='Slug of this entity')),
+        __config__=Config,
+        __validators__={'slug_validator': validator('slug', allow_reuse=True)(schemas.validate_slug)}
+    )
+    return model
 
 
 def route_create_entity(router: APIRouter, schema: Schema, get_db: Callable):
+    entity_create_schema = _create_entity_request_model(schema=schema)
     @router.post(
-        f'/{schema.slug}'
+        f'/{schema.slug}',
+        response_model=schemas.EntityBaseSchema,
+        tags=[schema.name],
+        summary=f'Create new {schema.name} entity',
+        responses={
+            404: {
+                'description': '''Can be returned when:
+
+                * schema, this new entity belongs to, doesn't exist or is deleted;
+                * passed attribute doesn't exist on current schema;
+                * entity passed in FK field doesn't exist.
+                '''
+            },
+            409: {
+                'description': '''Can be returned when:
+
+                * entity with provided slug already exists on current schema;
+                * there already exists an entity that has same value for unique field and this entity is not deleted.
+                '''
+            },
+            422: {
+                'description': '''Can be returned when:
+
+                * passed data doesn't follow schema requirements;
+                * entity, passed to FK field, doesn't belong to schema this field is bound to.
+                '''
+            }
+        }
     )
-    def create_entity(data: dict, db: Session = Depends(get_db)):
+    def create_entity(data: entity_create_schema, db: Session = Depends(get_db)):
         try:
-            return crud.create_entity(db=db, schema_id=schema.id, data=data)
-        except exceptions.RequiredFieldException:
-            raise HTTPException(status.HTTP_404_NOT_FOUND)
-        except exceptions.MissingSchemaException:
-            raise HTTPException(status.HTTP_404_NOT_FOUND)
-        except exceptions.AttributeNotDefinedException:
-            raise HTTPException(status.HTTP_404_NOT_FOUND)
-        except exceptions.NotListedAttributeException:
-            raise HTTPException(status.HTTP_404_NOT_FOUND)
-        except exceptions.MissingEntityException:
-            raise HTTPException(status.HTTP_404_NOT_FOUND)
-        except exceptions.WrongSchemaToBindException:
-            raise HTTPException(status.HTTP_404_NOT_FOUND)
-        except exceptions.UniqueValueException:
-            raise HTTPException(status.HTTP_404_NOT_FOUND)
+            return crud.create_entity(db=db, schema_id=schema.id, data=data.dict())
+        except exceptions.MissingSchemaException as e:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        except exceptions.EntityExistsException as e:
+            raise HTTPException(status.HTTP_409_CONFLICT, str(e))
+        except exceptions.AttributeNotDefinedException as e:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        except exceptions.NotListedAttributeException as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
+        except exceptions.MissingEntityException as e:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        except exceptions.WrongSchemaToBindException as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
+        except exceptions.UniqueValueException as e:
+            raise HTTPException(status.HTTP_409_CONFLICT, str(e))
+
+
+def _update_entity_request_model(schema: Schema) -> ModelMetaclass:
+    '''
+    Creates Pydantic entity update model
+
+    Model includes all entity attributes as `Optional` fields,
+    with descriptions taken from `AttributeDefinition`,
+    plus `Optional` `slug` field with custom validator for it.
+
+    This model will raise exception if passed fields that don't
+    belong to it.
+    '''
+    field_names = [i.attribute.name for i in schema.attr_defs]
+    types = [_make_type(i, optional=True) for i in schema.attr_defs]
+    fields_types = dict(zip(field_names, types))
+    
+    class Config:
+        extra = 'forbid'
+    
+    model = create_model(
+        f"{schema.slug.capitalize().replace('-', '_')}Update",
+        **fields_types,
+        slug=(Optional[str], Field(description='Slug of this entity')),
+        __config__=Config,
+        __validators__={'slug_validator': validator('slug', allow_reuse=True)(schemas.validate_slug)}
+    )
+    return model
+
+
+def route_update_entity(router: APIRouter, schema: Schema, get_db: Callable):
+    entity_update_schema = _update_entity_request_model(schema=schema)
+    @router.put(
+        f'/{schema.slug}/{{id_or_slug}}',
+        response_model=schemas.EntityBaseSchema,
+        tags=[schema.name],
+        summary=f'Update {schema.name} entity',
+        responses={
+            404: {
+                'description': '''Can be returned when:
+
+                * entity with provided id/slug doesn't exist on current schema;
+                * schema, this entity belongs to, is deleted;
+                * passed attribute doesn't exist on current schema;
+                * schema, this new entity belongs to, doesn't exist or is deleted;
+                * entity passed in FK field doesn't exist.
+                '''
+            },
+            409: {
+                'description': '''Can be returned when:
+                
+                * entity with provided slug already exists on current schema;
+                * there already exists an entity that has same value for unique field and this entity is not deleted
+                '''
+            },
+            422: {
+                'description': '''Can be returned when:
+
+                * passed data doesn't follow schema requirements;
+                * there were passed multiple values for field that is not defined as listed;
+                * entity, passed to FK field, doesn't belong to schema this field is bound to
+                '''
+            }
+        }
+    )
+    def update_entity(id_or_slug: Union[int, str], data: entity_update_schema, db: Session = Depends(get_db)):
+        try:
+            return crud.update_entity(db=db, id_or_slug=id_or_slug, schema_id=schema.id, data=data.dict(exclude_unset=True))
+        except exceptions.MissingEntityException as e:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        except exceptions.MissingSchemaException as e:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        except exceptions.EntityExistsException as e:
+            raise HTTPException(status.HTTP_409_CONFLICT, str(e))
+        except exceptions.WrongSchemaToBindException as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
+        except exceptions.UniqueValueException as e:
+            raise HTTPException(status.HTTP_409_CONFLICT, str(e))
+        except exceptions.RequiredFieldException as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e)) 
 
 
 def create_dynamic_router(schema: Schema, app: FastAPI, get_db: Callable):
@@ -74,6 +309,7 @@ def create_dynamic_router(schema: Schema, app: FastAPI, get_db: Callable):
     route_get_entity(router=router, schema=schema, get_db=get_db)
     route_get_entities(router=router, schema=schema, get_db=get_db)
     route_create_entity(router=router, schema=schema, get_db=get_db)
+    route_update_entity(router=router, schema=schema, get_db=get_db)
 
     app.include_router(router, prefix='')
     app.openapi_schema = None

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -1,0 +1,79 @@
+from typing import List, Callable
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.applications import FastAPI
+from sqlalchemy.orm.session import Session
+
+from .models import Schema
+from . import crud, exceptions
+
+
+def route_get_entity(router: APIRouter, schema: Schema, get_db: Callable):
+    @router.get(
+        f'/{schema.slug}/{{entity_id}}',
+    )
+    def get_entity(entity_id: int, db: Session = Depends(get_db)):
+        try:
+            return crud.get_entity(db=db, entity_id=entity_id, schema=schema)
+        except exceptions.MissingEntityException as e:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        
+
+def route_get_entities(router: APIRouter, schema: Schema, get_db: Callable):
+    @router.get(
+        f'/{schema.slug}'
+    )
+    def get_entities(
+            limit: int = None, 
+            offset: int = None, 
+            all: bool = False, 
+            deleted_only: bool = False, 
+            all_fields: bool = False, 
+            db: Session = Depends(get_db)
+        ):
+        try:
+            return crud.get_entities(
+                db=db, 
+                schema=schema,
+                limit=limit,
+                offset=offset,
+                all=all,
+                deleted_only=deleted_only,
+                all_fields=all_fields
+            )
+        except exceptions.MissingSchemaException as e:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+
+
+def route_create_entity(router: APIRouter, schema: Schema, get_db: Callable):
+    @router.post(
+        f'/{schema.slug}'
+    )
+    def create_entity(data: dict, db: Session = Depends(get_db)):
+        try:
+            return crud.create_entity(db=db, schema_id=schema.id, data=data)
+        except exceptions.RequiredFieldException:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        except exceptions.MissingSchemaException:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        except exceptions.AttributeNotDefinedException:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        except exceptions.NotListedAttributeException:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        except exceptions.MissingEntityException:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        except exceptions.WrongSchemaToBindException:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        except exceptions.UniqueValueException:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+
+def create_dynamic_router(schema: Schema, app: FastAPI, get_db: Callable):
+    router = APIRouter()
+    
+    route_get_entity(router=router, schema=schema, get_db=get_db)
+    route_get_entities(router=router, schema=schema, get_db=get_db)
+    route_create_entity(router=router, schema=schema, get_db=get_db)
+
+    app.include_router(router, prefix='')
+    app.openapi_schema = None

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -29,7 +29,7 @@ def _get_entity_request_model(schema: Schema, name: str) -> ModelMetaclass:
 
     Model includes all entity attributes, which are all marked as `Optional`,
     and their descriptions, if defined in `AttributeDefinition`.
-    Also includes fields `id`, `slug` and `deleted`.
+    Also includes fields `id`, `slug`, `name` and `deleted`.
 
     Why attributes are `Optional`: currently, if we add new requried
     field to schema, which already holds some entities, values for this
@@ -48,7 +48,8 @@ def _get_entity_request_model(schema: Schema, name: str) -> ModelMetaclass:
     default_fields = {
         'id': (int, Field(description='ID of this entity')),
         'deleted': (bool, Field(description='Indicates whether this entity is marked as deleted')),
-        'slug': (str, Field(description='Slug for this entity'))
+        'slug': (str, Field(description='Slug for this entity')),
+        'name': (str, Field(description='Name of this entity'))
     }
     model = create_model(
         name,
@@ -150,7 +151,8 @@ def _create_entity_request_model(schema: Schema) -> ModelMetaclass:
 
     Model includes all entity attributes, which are marked as `Optional`
     if defined so in `AttributeDefinition`,
-    plus required `slug` field with custom validator for it.
+    plus required `slug` field with custom validator for it and required
+    `name` field.
 
     This model will raise exception if passed fields that don't
     belong to it.
@@ -166,6 +168,7 @@ def _create_entity_request_model(schema: Schema) -> ModelMetaclass:
         f"{schema.slug.capitalize().replace('-', '_')}Create",
         **fields_types,
         slug=(str, Field(description='Slug of this entity')),
+        name=(str, Field(description='Name of this entity')),
         __config__=Config,
         __validators__={'slug_validator': validator('slug', allow_reuse=True)(schemas.validate_slug)}
     )
@@ -229,7 +232,8 @@ def _update_entity_request_model(schema: Schema) -> ModelMetaclass:
 
     Model includes all entity attributes as `Optional` fields,
     with descriptions taken from `AttributeDefinition`,
-    plus `Optional` `slug` field with custom validator for it.
+    plus `Optional` `slug` field with custom validator for it
+    and `Optional` `name` field.
 
     This model will raise exception if passed fields that don't
     belong to it.
@@ -245,6 +249,7 @@ def _update_entity_request_model(schema: Schema) -> ModelMetaclass:
         f"{schema.slug.capitalize().replace('-', '_')}Update",
         **fields_types,
         slug=(Optional[str], Field(description='Slug of this entity')),
+        name=(Optional[str], Field(description='Name of this entity')),
         __config__=Config,
         __validators__={'slug_validator': validator('slug', allow_reuse=True)(schemas.validate_slug)}
     )

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -147,9 +147,14 @@ def route_get_entities(router: APIRouter, schema: Schema, get_db: Callable):
     entity_schema = _get_entity_request_model(schema=schema, name=f"{schema.slug.capitalize().replace('-', '_')}ListItem")
     description = _description_for_get_entities(schema=schema)
     filter_model = _filters_request_model(schema=schema)
+    response_model = create_model(
+        f'Get{entity_schema.__name__}', 
+        total=(int, Field(description='Total number of entities satisfying conditions')),
+        entities=(List[entity_schema], Field(description='List of returned entities'))
+    )
     @router.get(
         f'/{schema.slug}',
-        response_model=List[entity_schema],
+        response_model=response_model,
         tags=[schema.name],
         summary=f'List {schema.name} entities',
         description=description,

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -176,17 +176,21 @@ def route_get_entities(router: APIRouter, schema: Schema, get_db: Callable):
             attr = split[0]
             filter = split[-1] if len(split) > 1 else 'eq'
             new_filters[f'{attr}.{filter}'] = v
-
-        return crud.get_entities(
-            db=db, 
-            schema=schema,
-            limit=limit,
-            offset=offset,
-            all=all,
-            deleted_only=deleted_only,
-            all_fields=all_fields,
-            filters=new_filters
-        )
+        try:
+            return crud.get_entities(
+                db=db, 
+                schema=schema,
+                limit=limit,
+                offset=offset,
+                all=all,
+                deleted_only=deleted_only,
+                all_fields=all_fields,
+                filters=new_filters
+            )  # these two exceptions are not supposed to be ever raised
+        except exceptions.InvalidFilterAttributeException as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
+        except exceptions.InvalidFilterOperatorException as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
        
 
 def _create_entity_request_model(schema: Schema) -> ModelMetaclass:

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -172,8 +172,8 @@ def route_get_entities(router: APIRouter, schema: Schema, get_db: Callable):
         filters = {k: v for k, v in filters.__dict__.items() if v is not None}
         new_filters = {}
         for k, v in filters.items():
-            split = k.split('_')
-            attr = '_'.join(split[:-1]) if len(split) > 1 else split[0]
+            split = k.rsplit('_', maxsplit=1)
+            attr = split[0]
             filter = split[-1] if len(split) > 1 else 'eq'
             new_filters[f'{attr}.{filter}'] = v
 

--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -140,7 +140,7 @@ def _filters_request_model(schema: Schema):
 
     for attr_def in schema.attr_defs:
         attr = attr_def.attribute
-        if attr.type not in crud.ALLOWED_FILTERS or attr_def.list:
+        if attr.type not in crud.ALLOWED_FILTERS:
             continue
 
         type_ = (attr.type  # Attribute.type -> AttrType

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -125,3 +125,12 @@ class ReservedAttributeException(Exception):
 
     def __str__(self) -> str:
         return f"Can't create attribute `{self.attr_name}`. List of reserved attribute names: {', '.join(self.reserved)}"
+
+
+class ReservedSchemaSlugException(Exception):
+    def __init__(self, slug: str, reserved: List[str]):
+        self.slug = slug
+        self.reserved = reserved
+
+    def __str__(self) -> str:
+        return f"Can't create schema with slug `{self.slug}`. List of reserved schema slugs: {', '.join(self.reserved)}"

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -11,6 +11,13 @@ class SchemaExistsException(Exception):
     def __str__(self) -> str:
         return f'Schema with name `{self.name}` or slug `{self.slug}` already exists'
 
+class EntityExistsException(Exception):
+    def __init__(self, slug: str):
+        self.slug = slug
+
+    def __str__(self) -> str:
+        return f'Entity with slug `{self.slug}` already exists in this schema'
+
 class MissingObjectException(Exception):
     obj_type: str
 

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -58,7 +58,7 @@ class WrongSchemaToBindException(Exception):
         self.passed_entity = passed_entity
 
     def __str__(self) -> str:
-        return f'Attribute `f{self.attr_name}` defined on schema ({self.schema_id}) is bound to schema ({self.bound_schema_id}); got instead entity ({self.passed_entity.id}) from schema ({self.passed_entity.schema_id})'
+        return f'Attribute `{self.attr_name}` defined on schema ({self.schema_id}) is bound to schema ({self.bound_schema_id}); got instead entity ({self.passed_entity.id}) from schema ({self.passed_entity.schema_id})'
 
 class AttributeAlreadyDefinedException(Exception):
     def __init__(self, attr_id: int, schema_id: int):

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -134,3 +134,21 @@ class ReservedSchemaSlugException(Exception):
 
     def __str__(self) -> str:
         return f"Can't create schema with slug `{self.slug}`. List of reserved schema slugs: {', '.join(self.reserved)}"
+
+
+class InvalidFilterOperatorException(Exception):
+    def __init__(self, attr: str, filter: str):
+        self.attr = attr
+        self.filter = filter
+
+    def __str__(self) -> str:
+        return f'`{self.filter}` is invalid filter for attribute {self.attr}'
+
+
+class InvalidFilterAttributeException(Exception):
+    def __init__(self, attr: str, allowed_attrs: List[str]):
+        self.attr = attr
+        self.allowed_attrs = allowed_attrs
+
+    def __str__(self) -> str:
+        return f"Can't filter current schema by attribute `{self.attr}`. Allowed attributes: {', '.join(self.allowed_attrs)}"

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 from .models import Entity
 
@@ -100,3 +100,21 @@ class RequiredFieldException(Exception):
 
     def __str__(self) -> str:
         return f'Missing required field: {self.field}'
+
+
+class MismatchingSchemaException(Exception):
+    def __init__(self, entity_id: int, schema_id: int):
+        self.entity_id = entity_id
+        self.schema_id = schema_id
+
+    def __str__(self) -> str:
+        return f"Requested Entity ({self.entity_id}) doesn't belong to specified Schema ({self.schema_id})"
+
+
+class ReservedAttributeException(Exception):
+    def __init__(self, attr_name: str, reserved: List[str]):
+        self.attr_name = attr_name
+        self.reserved = reserved
+
+    def __str__(self) -> str:
+        return f"Can't create attribute `{self.attr_name}`. List of reserved attribute names: {', '.join(self.reserved)}"

--- a/backend/general_routes.py
+++ b/backend/general_routes.py
@@ -54,6 +54,8 @@ def create_schema(data: schemas.SchemaCreateSchema, request: Request, db: Sessio
         schema = crud.create_schema(db=db, data=data)
         create_dynamic_router(schema=schema, app=request.app, get_db=get_db)
         return schema
+    except exceptions.ReservedSchemaSlugException as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(e))
     except exceptions.SchemaExistsException as e:
         raise HTTPException(status.HTTP_409_CONFLICT, str(e))
     except exceptions.MissingAttributeException as e:
@@ -89,6 +91,8 @@ def update_schema(data: schemas.SchemaUpdateSchema, id_or_slug: Union[int, str],
         schema = crud.update_schema(db=db, id_or_slug=id_or_slug, data=data)
         create_dynamic_router(schema=schema, old_slug=old_slug, app=request.app, get_db=get_db)
         return schema
+    except exceptions.ReservedSchemaSlugException as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(e))
     except exceptions.MissingAttributeException as e:
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
     except exceptions.MissingSchemaException as e:

--- a/backend/general_routes.py
+++ b/backend/general_routes.py
@@ -85,8 +85,9 @@ def get_schema(id_or_slug: Union[int, str], db: Session = Depends(get_db)):
 )
 def update_schema(data: schemas.SchemaUpdateSchema, id_or_slug: Union[int, str], request: Request, db: Session = Depends(get_db)):
     try:
+        old_slug = crud.get_schema(db=db, id_or_slug=id_or_slug).slug
         schema = crud.update_schema(db=db, id_or_slug=id_or_slug, data=data)
-        create_dynamic_router(schema=schema, app=request.app, get_db=get_db)
+        create_dynamic_router(schema=schema, old_slug=old_slug, app=request.app, get_db=get_db)
         return schema
     except exceptions.MissingAttributeException as e:
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))

--- a/backend/general_routes.py
+++ b/backend/general_routes.py
@@ -1,0 +1,76 @@
+from typing import Optional, List, Union
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from . import crud, schemas, exceptions
+from .database import get_db
+from .dynamic_routes import create_dynamic_router
+
+
+router = APIRouter()
+
+@router.get('/attributes', response_model=List[schemas.AttributeSchema])
+def get_attributes(db: Session = Depends(get_db)):
+    return crud.get_attributes(db)
+
+
+@router.get('/attributes/{attr_id}', response_model=schemas.AttributeSchema)
+def get_attribute(attr_id: int, db: Session = Depends(get_db)):
+    try:
+        return crud.get_attribute(db=db, attr_id=attr_id)
+    except exceptions.MissingAttributeException as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+
+
+@router.get('/schemas', response_model=List[schemas.SchemaForListSchema])
+def get_schemas(all: Optional[bool] = False, deleted_only: Optional[bool] = False, db: Session = Depends(get_db)):
+    return crud.get_schemas(db=db, all=all, deleted_only=deleted_only)
+
+
+@router.post('/schemas', response_model=schemas.SchemaForListSchema)
+def create_schema(data: schemas.SchemaCreateSchema, db: Session = Depends(get_db)):
+    try:
+        schema = crud.create_schema(db=db, data=data)
+        create_dynamic_router(schema=schema, app=router, get_db=get_db)
+        return schema
+    except exceptions.SchemaExistsException as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(e))
+    except exceptions.MissingAttributeException as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+    except exceptions.MultipleAttributeOccurencesException as e:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(e))
+    except exceptions.NoSchemaToBindException as e:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
+    except exceptions.MissingSchemaException as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+
+
+@router.get('/schemas/{id_or_slug}', response_model=schemas.SchemaDetailSchema)
+def get_schema(id_or_slug: Union[int, str], db: Session = Depends(get_db)):
+    try:
+        return crud.get_schema(db=db, id_or_slug=id_or_slug)
+    except exceptions.MissingSchemaException:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+
+@router.put('/schemas/{id}', response_model=schemas.SchemaDetailSchema)
+def update_schema(data: schemas.SchemaUpdateSchema, id: int, db: Session = Depends(get_db)):
+    try:
+        return crud.update_schema(db=db, schema_id=id, data=data)
+    except exceptions.MissingSchemaException:
+        pass
+    except exceptions.SchemaExistsException:
+        pass
+    except exceptions.AttributeNotDefinedException:
+        pass
+    except exceptions.ListedToUnlistedException:
+        pass
+    except exceptions.MultipleAttributeOccurencesException:
+        pass
+    except exceptions.AttributeAlreadyDefinedException:
+        pass
+    except exceptions.NoSchemaToBindException:
+        pass
+       
+

--- a/backend/general_routes.py
+++ b/backend/general_routes.py
@@ -109,5 +109,16 @@ def update_schema(data: schemas.SchemaUpdateSchema, id_or_slug: Union[int, str],
         raise HTTPException(status.HTTP_409_CONFLICT, str(e))
     except exceptions.NoSchemaToBindException as e:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
-       
 
+
+@router.delete(
+    '/schemas/{id_or_slug}', 
+    response_model=schemas.SchemaDetailSchema,
+    response_model_exclude=['attributes', 'attr_defs'],
+    tags=['General routes']
+)
+def delete_schema(id_or_slug: Union[int, str], db: Session = Depends(get_db)):
+    try:
+        return crud.delete_schema(db=db, id_or_slug=id_or_slug)
+    except exceptions.MissingSchemaException as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,6 @@
+from . import create_app, models
+from .database import engine
+
+
+models.Base.metadata.create_all(engine)
+app = create_app()

--- a/backend/models.py
+++ b/backend/models.py
@@ -104,13 +104,17 @@ class Schema(Base):
 
 class Entity(Base):
     __tablename__ = 'entities'
-
+    
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(128), nullable=False)
+    slug = Column(String(128), nullable=False)
     schema_id = Column(Integer, ForeignKey('schemas.id'))
     deleted = Column(Boolean, default=False)
 
     schema = relationship('Schema', back_populates='entities')
+
+    __table_args__ = (
+        UniqueConstraint('slug', 'schema_id'),
+    )
 
     def get(self, attr_name: str, db: Session) -> Union[Optional[Value], List[Value]]:
         attr_def: AttributeDefinition = db.execute(

--- a/backend/models.py
+++ b/backend/models.py
@@ -106,6 +106,7 @@ class Entity(Base):
     __tablename__ = 'entities'
     
     id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(128), nullable=False)
     slug = Column(String(128), nullable=False)
     schema_id = Column(Integer, ForeignKey('schemas.id'))
     deleted = Column(Boolean, default=False)

--- a/backend/models.py
+++ b/backend/models.py
@@ -70,7 +70,7 @@ class AttrType(enum.Enum):
     INT = Mapping(ValueInt, int)
     FLOAT = Mapping(ValueFloat, float)
     FK = Mapping(ValueForeignKey, int)
-    DT = Mapping(ValueDatetime, datetime.fromtimestamp)
+    DT = Mapping(ValueDatetime, lambda x: x)
 
 
 class BoundFK(Base):

--- a/backend/models.py
+++ b/backend/models.py
@@ -56,7 +56,7 @@ class ValueStr(Value):
 
 class ValueDatetime(Value):
     __tablename__ = 'values_datetime'
-    value = Column(DateTime)
+    value = Column(DateTime(timezone=True))
 
 
 class Mapping(NamedTuple):

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -57,7 +57,7 @@ class AttributeDefinitionUpdateWithNameSchema(AttributeDefinitionBase):
 
 
 def validate_slug(cls, slug: str):
-    if re.match('^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$', slug) is None:
+    if re.match('^[a-zA-Z]+[0-9]*(-[a-zA-Z0-9]+)*$', slug) is None:
         raise ValueError(f'`{slug}` is invalid value for slug field')
     return slug
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -128,3 +128,8 @@ class EntityBaseSchema(BaseModel):
     slug_validator = validator('slug', allow_reuse=True)(validate_slug)
     class Config:
         orm_mode = True
+
+
+class EntityListSchema(BaseModel):
+    total: int
+    entities: List[dict]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -39,7 +39,11 @@ class AttrDefWithAttrDataSchema(AttributeDefinitionBase, AttributeCreateSchema):
 
 
 class AttributeDefinitionUpdateSchema(AttributeDefinitionBase):
-    id: int
+    attr_def_id: int
+
+
+class AttributeDefinitionUpdateWithNameSchema(AttributeDefinitionBase):
+    name: str
 
 
 class SchemaCreateSchema(BaseModel):
@@ -52,5 +56,5 @@ class SchemaUpdateSchema(BaseModel):
     name: str
     slug: str
 
-    update_attributes: List[AttributeDefinitionUpdateSchema]
+    update_attributes: List[Union[AttributeDefinitionUpdateSchema, AttributeDefinitionUpdateWithNameSchema]]
     add_attributes: List[Union[AttrDefSchema, AttrDefWithAttrDataSchema]]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -117,3 +117,12 @@ class AttributeSchema(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class EntityBaseSchema(BaseModel):
+    id: int
+    slug: str
+    
+    slug_validator = validator('slug', allow_reuse=True)(validate_slug)
+    class Config:
+        orm_mode = True

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -122,6 +122,7 @@ class AttributeSchema(BaseModel):
 class EntityBaseSchema(BaseModel):
     id: int
     slug: str
+    name: str
     
     slug_validator = validator('slug', allow_reuse=True)(validate_slug)
     class Config:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from typing import List, Optional, Union, Any
 
@@ -33,6 +34,7 @@ class AttributeDefinitionBase(BaseModel):
         orm_mode = True
         allow_population_by_field_name = True
 
+
 class AttrDefSchema(AttributeDefinitionBase):
     attr_id: int = Field(alias='attribute_id')
 
@@ -54,10 +56,18 @@ class AttributeDefinitionUpdateWithNameSchema(AttributeDefinitionBase):
     name: str
 
 
+def validate_slug(cls, slug: str):
+    if re.match('^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$', slug) is None:
+        raise ValueError(f'`{slug}` is invalid value for slug field')
+    return slug
+
+
 class SchemaCreateSchema(BaseModel):
     name: str
     slug: str
     attributes: List[Union[AttrDefSchema, AttrDefWithAttrDataSchema]]
+
+    slug_validator = validator('slug', allow_reuse=True)(validate_slug)
 
 
 class SchemaUpdateSchema(BaseModel):
@@ -67,11 +77,15 @@ class SchemaUpdateSchema(BaseModel):
     update_attributes: List[Union[AttributeDefinitionUpdateSchema, AttributeDefinitionUpdateWithNameSchema]]
     add_attributes: List[Union[AttrDefSchema, AttrDefWithAttrDataSchema]]
 
+    slug_validator = validator('slug', allow_reuse=True)(validate_slug)
+
 
 class SchemaBaseSchema(BaseModel):
     id: int
     name: str
     slug: str
+
+    slug_validator = validator('slug', allow_reuse=True)(validate_slug)
 
     class Config:
         orm_mode = True

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -123,7 +123,8 @@ class EntityBaseSchema(BaseModel):
     id: int
     slug: str
     name: str
-    
+    deleted: bool
+
     slug_validator = validator('slug', allow_reuse=True)(validate_slug)
     class Config:
         orm_mode = True

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,7 +31,7 @@ def populate_db(db: Session):
       age    |    2    |     +    |   -    |   -  |  + 
       born   |    4    |     -    |   -    |   -  |  - 
       friends|    5    |     +    |   -    |   +  |  - 
-    nickname |    7    |     +    |   +    |   -  |  -
+    nickname |    7    |     -    |   +    |   -  |  -
 
     ### Bound FKs
 
@@ -89,7 +89,7 @@ def populate_db(db: Session):
     nickname_ = AttributeDefinition(
         schema_id=person.id,
         attribute_id=nickname.id,
-        required=True,
+        required=False,
         unique=True,
         list=False,
         key=False

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -42,10 +42,10 @@ def populate_db(db: Session):
     ### Entities
       *Person*
 
-      id |  slug  | age | born | friends | nickname |
-      ---|--------|-----|------|---------|----------|
-      1  | Jack   | 10  |   -  |   []    | jack     |
-      2  | Jane   | 12  |   -  |   [1]   | jane     |
+      id |  slug  | age | born | friends | nickname | name
+      ---|--------|-----|------|---------|----------|-----
+      1  | Jack   | 10  |   -  |   []    | jack     | Jack
+      2  | Jane   | 12  |   -  |   [1]   | jane     | Jane
     
     '''
     age_float = Attribute(name='age', type=AttrType.FLOAT)
@@ -99,13 +99,13 @@ def populate_db(db: Session):
     bfk = BoundFK(attr_def_id=friends_.id, schema_id=person.id)
     db.add(bfk)
 
-    p1 = Entity(schema_id=person.id, slug='Jack')
+    p1 = Entity(schema_id=person.id, slug='Jack', name='Jack')
     db.add(p1)
     db.flush()
     p1_nickname = ValueStr(entity_id=p1.id, attribute_id=nickname.id, value='jack')
     p1_age = ValueInt(entity_id=p1.id, attribute_id=age_int.id, value=10)
 
-    p2 = Entity(schema_id=person.id, slug='Jane')
+    p2 = Entity(schema_id=person.id, slug='Jane', name='Jane')
     db.add(p2)
     db.flush()
     p2_nickname = ValueStr(entity_id=p2.id, attribute_id=nickname.id, value='jane')

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,7 @@ def populate_db(db: Session):
         friends|  5 | FK
         address|  6 | FK
       nickname |  7 | STR
+      fav_color|  8 | STR
 
     ### Schemas
       1. Person (person), fields:
@@ -32,6 +33,7 @@ def populate_db(db: Session):
       born   |    4    |     -    |   -    |   -  |  - 
       friends|    5    |     +    |   -    |   +  |  - 
     nickname |    7    |     -    |   +    |   -  |  -
+    fav_color|    8    |     -    |   -    |   +  |  -
 
     ### Bound FKs
 
@@ -42,10 +44,10 @@ def populate_db(db: Session):
     ### Entities
       *Person*
 
-      id |  slug  | age | born | friends | nickname | name
-      ---|--------|-----|------|---------|----------|-----
-      1  | Jack   | 10  |   -  |   []    | jack     | Jack
-      2  | Jane   | 12  |   -  |   [1]   | jane     | Jane
+      id |  slug  | age | born | friends | nickname | name | fav_color
+      ---|--------|-----|------|---------|----------|------|----------
+      1  | Jack   | 10  |   -  |   []    | jack     | Jack | red, blue
+      2  | Jane   | 12  |   -  |   [1]   | jane     | Jane | red, black
     
     '''
     age_float = Attribute(name='age', type=AttrType.FLOAT)
@@ -55,7 +57,8 @@ def populate_db(db: Session):
     friends = Attribute(name='friends', type=AttrType.FK)
     address = Attribute(name='address', type=AttrType.FK)
     nickname = Attribute(name='nickname', type=AttrType.STR)
-    db.add_all([age_float, age_int, age_str, born, friends, address, nickname])
+    fav_color = Attribute(name='fav_color', type=AttrType.STR)
+    db.add_all([age_float, age_int, age_str, born, friends, address, nickname, fav_color])
 
     person = Schema(name='Person', slug='person')
     db.add(person)
@@ -94,7 +97,15 @@ def populate_db(db: Session):
         list=False,
         key=False
     )
-    db.add_all([age_, born_, friends_, nickname_])
+    fav_color_ = AttributeDefinition(
+        schema_id=person.id,
+        attribute_id=fav_color.id,
+        required=False,
+        unique=False,
+        list=True,
+        key=False
+    )
+    db.add_all([age_, born_, friends_, nickname_, fav_color_])
     db.flush()
     bfk = BoundFK(attr_def_id=friends_.id, schema_id=person.id)
     db.add(bfk)
@@ -104,6 +115,8 @@ def populate_db(db: Session):
     db.flush()
     p1_nickname = ValueStr(entity_id=p1.id, attribute_id=nickname.id, value='jack')
     p1_age = ValueInt(entity_id=p1.id, attribute_id=age_int.id, value=10)
+    p1_fav_color_1 = ValueStr(value='red', entity_id=p1.id, attribute_id=fav_color.id)
+    p1_fav_color_2 = ValueStr(value='blue', entity_id=p1.id, attribute_id=fav_color.id)
 
     p2 = Entity(schema_id=person.id, slug='Jane', name='Jane')
     db.add(p2)
@@ -111,8 +124,10 @@ def populate_db(db: Session):
     p2_nickname = ValueStr(entity_id=p2.id, attribute_id=nickname.id, value='jane')
     p2_age = ValueInt(entity_id=p2.id, attribute_id=age_int.id, value=12)
     p2_friend = ValueForeignKey(entity_id=p2.id, attribute_id=friends.id, value=p1.id)
+    p2_fav_color_1 = ValueStr(value='red', entity_id=p2.id, attribute_id=fav_color.id)
+    p2_fav_color_2 = ValueStr(value='black', entity_id=p2.id, attribute_id=fav_color.id)
 
-    db.add_all([p1_nickname, p1_age, p2_nickname, p2_age, p2_friend])
+    db.add_all([p1_nickname, p1_age, p2_nickname, p2_age, p2_friend,p1_fav_color_1, p1_fav_color_2, p2_fav_color_1, p2_fav_color_2])
     db.commit()
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,25 +15,23 @@ def populate_db(db: Session):
 
         name   | id | type
         -------|----|-----
-        name   |  1 | STR
-        age    |  2 | FLOAT
-        age    |  3 | INT
-        age    |  4 | STR
-        born   |  5 | DT
-        friends|  6 | FK
-        address|  7 | FK
-      nickname |  8 | STR
+        age    |  1 | FLOAT
+        age    |  2 | INT
+        age    |  3 | STR
+        born   |  4 | DT
+        friends|  5 | FK
+        address|  6 | FK
+      nickname |  7 | STR
 
     ### Schemas
       1. Person (person), fields:
 
       name   | attr_id | required | unique | list | key
       -------|---------|----------|--------|------|----
-      name   |    1    |     +    |   +    |   -  |  + 
-      age    |    3    |     +    |   -    |   -  |  + 
-      born   |    5    |     -    |   -    |   -  |  - 
-      friends|    6    |     +    |   -    |   +  |  - 
-    nickname |    8    |     +    |   +    |   -  |  -
+      age    |    2    |     +    |   -    |   -  |  + 
+      born   |    4    |     -    |   -    |   -  |  - 
+      friends|    5    |     +    |   -    |   +  |  - 
+    nickname |    7    |     +    |   +    |   -  |  -
 
     ### Bound FKs
 
@@ -44,13 +42,12 @@ def populate_db(db: Session):
     ### Entities
       *Person*
 
-      id |  name  | age | born | friends | nickname
-      ---|--------|-----|------|---------|------
-      1  | Jack   | 10  |   -  |   []    | jack
-      2  | Jane   | 12  |   -  |   [1]   | jane
+      id |  name  | age | born | friends | nickname |
+      ---|--------|-----|------|---------|----------|
+      1  | Jack   | 10  |   -  |   []    | jack     |
+      2  | Jane   | 12  |   -  |   [1]   | jane     |
     
     '''
-    name = Attribute(name='name', type=AttrType.STR)
     age_float = Attribute(name='age', type=AttrType.FLOAT)
     age_int = Attribute(name='age', type=AttrType.INT)
     age_str = Attribute(name='age', type=AttrType.STR)
@@ -58,21 +55,12 @@ def populate_db(db: Session):
     friends = Attribute(name='friends', type=AttrType.FK)
     address = Attribute(name='address', type=AttrType.FK)
     nickname = Attribute(name='nickname', type=AttrType.STR)
-    db.add_all([name, age_float, age_int, age_str, born, friends, address, nickname])
+    db.add_all([age_float, age_int, age_str, born, friends, address, nickname])
 
     person = Schema(name='Person', slug='person')
     db.add(person)
     db.flush()
-
-    name_ = AttributeDefinition(
-        schema_id=person.id,
-        attribute_id=name.id,
-        required=True,
-        unique=True,
-        list=False,
-        key=True,
-        description='Name of this person'
-    )
+    
     age_ = AttributeDefinition(
         schema_id=person.id,
         attribute_id=age_int.id,
@@ -106,7 +94,7 @@ def populate_db(db: Session):
         list=False,
         key=False
     )
-    db.add_all([name_, age_, born_, friends_, nickname_])
+    db.add_all([age_, born_, friends_, nickname_])
     db.flush()
     bfk = BoundFK(attr_def_id=friends_.id, schema_id=person.id)
     db.add(bfk)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -42,7 +42,7 @@ def populate_db(db: Session):
     ### Entities
       *Person*
 
-      id |  name  | age | born | friends | nickname |
+      id |  slug  | age | born | friends | nickname |
       ---|--------|-----|------|---------|----------|
       1  | Jack   | 10  |   -  |   []    | jack     |
       2  | Jane   | 12  |   -  |   [1]   | jane     |
@@ -99,13 +99,13 @@ def populate_db(db: Session):
     bfk = BoundFK(attr_def_id=friends_.id, schema_id=person.id)
     db.add(bfk)
 
-    p1 = Entity(schema_id=person.id, name='Jack')
+    p1 = Entity(schema_id=person.id, slug='Jack')
     db.add(p1)
     db.flush()
     p1_nickname = ValueStr(entity_id=p1.id, attribute_id=nickname.id, value='jack')
     p1_age = ValueInt(entity_id=p1.id, attribute_id=age_int.id, value=10)
 
-    p2 = Entity(schema_id=person.id, name='Jane')
+    p2 = Entity(schema_id=person.id, slug='Jane')
     db.add(p2)
     db.flush()
     p2_nickname = ValueStr(entity_id=p2.id, attribute_id=nickname.id, value='jane')

--- a/backend/tests/test_crud_attr.py
+++ b/backend/tests/test_crud_attr.py
@@ -13,16 +13,16 @@ class TestAttributeCRUD:
         assert attr.type == AttrType.STR
 
     def test_create_with_same_name(self, dbsession):
-        str_name = dbsession.execute(select(Attribute).where(Attribute.name == 'name')).scalar()
-        int_name = create_attribute(dbsession, data=AttributeCreateSchema(name='name', type=AttrTypeMapping.INT))
-        assert int_name.id != str_name.id
-        assert int_name.type != str_name.type
-        assert int_name.name == str_name.name
+        str_nickname = dbsession.execute(select(Attribute).where(Attribute.name == 'nickname')).scalar()
+        int_nickname = create_attribute(dbsession, data=AttributeCreateSchema(name='nickname', type=AttrTypeMapping.INT))
+        assert int_nickname.id != str_nickname.id
+        assert int_nickname.type != str_nickname.type
+        assert int_nickname.name == str_nickname.name
 
     def test_return_existing_on_duplicate(self, dbsession):
-        name = dbsession.execute(select(Attribute).where(Attribute.name == 'name')).scalar()
-        attr = create_attribute(dbsession, data=AttributeCreateSchema(name='name', type=AttrTypeMapping[name.type.name]))
-        assert attr.id == name.id
+        nickname = dbsession.execute(select(Attribute).where(Attribute.name == 'nickname')).scalar()
+        attr = create_attribute(dbsession, data=AttributeCreateSchema(name='nickname', type=AttrTypeMapping[nickname.type.name]))
+        assert attr.id == nickname.id
 
     def test_no_commit(self, dbsession):
         attrs = dbsession.execute(select(Attribute).where(Attribute.name == 'test')).scalars().all()

--- a/backend/tests/test_crud_attr.py
+++ b/backend/tests/test_crud_attr.py
@@ -61,9 +61,9 @@ class TestAttributeRead:
 
     def test_get_attributes(self, dbsession):
         attrs = get_attributes(dbsession)
-        assert len(attrs) == 7
+        assert len(attrs) == 8
         
-        names = {'age', 'born', 'friends', 'address', 'nickname'}
+        names = {'age', 'born', 'friends', 'address', 'nickname', 'fav_color'}
         assert set([i.name for i in attrs]) == names
 
     def test_raise_on_attr_doesnt_exist(self, dbsession):

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -203,7 +203,8 @@ class TestEntityRead:
             'age': 10,
             'friends': [],
             'born': None,
-            'nickname': 'jack'
+            'nickname': 'jack',
+            'fav_color': ['red', 'blue']
         }
         data = get_entity(dbsession, id_or_slug=jack.id, schema=jack.schema)
         assert data == expected
@@ -308,6 +309,9 @@ class TestEntityRead:
         ({'nickname.ne': 'jack'},     1, ['Jane']),
         ({'nickname.regexp': '^ja'},  2, ['Jack', 'Jane']),
         ({'nickname.contains': 'ne'}, 1, ['Jane']),
+        ({'fav_color.contains': 'b'}, 2, ['Jack', 'Jane']),
+        ({'fav_color.eq': 'black'},   1, ['Jane']),
+        ({'fav_color.ne': 'black'},   2, ['Jack', 'Jane'])  # still returns both even though Jane has black fav_color, but also has red
     ])
     def test_get_with_filter(self, dbsession, filters, ent_len, slugs):
         schema = dbsession.execute(select(Schema).where(Schema.id == 1)).scalar()

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -11,7 +11,7 @@ from ..exceptions import *
 
 class TestEntityCreate:
     def test_create(self, dbsession):
-        born = datetime(1990, 6, 30)
+        born = datetime(1990, 6, 30, tzinfo=timezone.utc)
         p1 = {
             'name': 'Mike',
             'slug': 'Mike',
@@ -387,7 +387,7 @@ class TestEntityRead:
 
 class TestEntityUpdate:
     def test_update(self, dbsession):
-        time = datetime.now()
+        time = datetime.now(timezone.utc)
         data = {
             'slug': 'test',
             'nickname': None,

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -296,16 +296,18 @@ class TestEntityRead:
 
 
     @pytest.mark.parametrize(['filters', 'ent_len', 'slugs'], [
-        ({'age': 10},             1, ['Jack']),
-        ({'age.eq': 10},          1, ['Jack']),
-        ({'age.ge': 10},          2, ['Jack', 'Jane']),
-        ({'age.gt': 10},          1, ['Jane']),
-        ({'age.le': 10},          1, ['Jack']),
-        ({'age.lt': 10},          0, []),
-        ({'age.ne': 10},          1, ['Jane']),
-        ({'name': 'Jane'},        1, ['Jane']),
-        ({'nickname': 'jane'},    1, ['Jane']),
-        ({'nickname.ne': 'jack'}, 1, ['Jane']),
+        ({'age': 10},                 1, ['Jack']),
+        ({'age.eq': 10},              1, ['Jack']),
+        ({'age.ge': 10},              2, ['Jack', 'Jane']),
+        ({'age.gt': 10},              1, ['Jane']),
+        ({'age.le': 10},              1, ['Jack']),
+        ({'age.lt': 10},              0, []),
+        ({'age.ne': 10},              1, ['Jane']),
+        ({'name': 'Jane'},            1, ['Jane']),
+        ({'nickname': 'jane'},        1, ['Jane']),
+        ({'nickname.ne': 'jack'},     1, ['Jane']),
+        ({'nickname.regexp': '^ja'},  2, ['Jack', 'Jane']),
+        ({'nickname.contains': 'ne'}, 1, ['Jane']),
     ])
     def test_get_with_filter(self, dbsession, filters, ent_len, slugs):
         schema = dbsession.execute(select(Schema).where(Schema.id == 1)).scalar()

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -404,21 +404,23 @@ class TestEntityUpdate:
 
 
 class TestEntityDelete:
-    def test_delete(self, dbsession):
-        e = dbsession.execute(select(Entity).where(Entity.id == 1)).scalar()
-        delete_entity(dbsession, entity_id=e.id)
+    @pytest.mark.parametrize('id_or_slug', [1, 'Jack'])
+    def test_delete(self, dbsession, id_or_slug):
+        delete_entity(dbsession, id_or_slug=id_or_slug, schema_id=1)
         
         entities = dbsession.execute(select(Entity)).scalars().all()
         assert len(entities) == 2
         e = dbsession.execute(select(Entity).where(Entity.id == 1)).scalar()
         assert e.deleted
 
-    def test_raise_on_entity_doesnt_exist(self, dbsession):
+    @pytest.mark.parametrize('id_or_slug', [1234567, 'qwertyu'])
+    def test_raise_on_entity_doesnt_exist(self, dbsession, id_or_slug):
         with pytest.raises(MissingEntityException):
-            delete_entity(dbsession, entity_id=9999999999)
+            delete_entity(dbsession, id_or_slug=id_or_slug, schema_id=1)
 
-    def test_raise_on_already_deleted(self, dbsession):
+    @pytest.mark.parametrize('id_or_slug', [1, 'Jack'])
+    def test_raise_on_already_deleted(self, dbsession, id_or_slug):
         dbsession.execute(update(Entity).where(Entity.id == 1).values(deleted=True))
         with pytest.raises(MissingEntityException):
-            delete_entity(dbsession, entity_id=1)
+            delete_entity(dbsession, id_or_slug=id_or_slug, schema_id=1)
         

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -150,6 +150,12 @@ class TestSchemaCreate:
         assert not attr_def.list
         assert attr_def.description == 'Test 1'
 
+    def test_raise_on_reserved_slug(self, dbsession):
+        for i in RESERVED_SCHEMA_SLUGS:
+            sch = SchemaCreateSchema(name='Person', slug=i, attributes=[])
+            with pytest.raises(ReservedSchemaSlugException):
+                create_schema(dbsession, data=sch)
+
     def test_raise_on_duplicate_name_or_slug(self, dbsession):
         sch = SchemaCreateSchema(name='Person', slug='test', attributes=[])
         with pytest.raises(SchemaExistsException):
@@ -492,7 +498,18 @@ class TestSchemaUpdate:
             .where(BoundFK.attr_def_id == test_def.id)
         ).scalar()
         assert bfk
-    
+
+    def test_raise_on_reserved_slig(self, dbsession):
+        for i in RESERVED_SCHEMA_SLUGS:
+            upd_schema = SchemaUpdateSchema(
+                name='Test', 
+                slug=i, 
+                update_attributes=[], 
+                add_attributes=[]
+            )
+            with pytest.raises(ReservedSchemaSlugException):
+                update_schema(dbsession, id_or_slug=1, data=upd_schema)
+
     def test_raise_on_schema_doesnt_exist(self, dbsession):
         upd_schema = SchemaUpdateSchema(
             name='Test', 

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -596,8 +596,27 @@ class TestSchemaUpdate:
             ]
         )
         with pytest.raises(AttributeAlreadyDefinedException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
+        dbsession.rollback()
 
+        upd_schema = SchemaUpdateSchema(
+            name='Test', 
+            slug='test', 
+            update_attributes=[], 
+            add_attributes=[
+                AttrDefWithAttrDataSchema(
+                    name='nickname',
+                    type=AttrTypeMapping.DT,
+                    required=True,
+                    unique=True,
+                    list=True,
+                    key=True
+                )
+            ]
+        )
+        with pytest.raises(AttributeAlreadyDefinedException):
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
+            
     def test_raise_on_nonexistent_schema_when_binding(self, dbsession):
         attr = dbsession.execute(
             select(Attribute)
@@ -644,10 +663,10 @@ class TestSchemaUpdate:
             update_schema(dbsession, schema_id=1, data=upd_schema)
 
     def test_raise_on_multiple_attrs_with_same_name(self, dbsession):
-        ages = dbsession.execute(
+        address = dbsession.execute(
             select(Attribute)
-            .where(Attribute.name == 'age')
-        ).scalars().all()
+            .where(Attribute.name == 'address')
+        ).scalar()
 
         upd_schema = SchemaUpdateSchema(
             name='Test', 
@@ -655,41 +674,15 @@ class TestSchemaUpdate:
             update_attributes=[], 
             add_attributes=[
                 AttrDefSchema(
-                    attr_id=ages[0].id,
+                    attr_id=address.id,
                     required=True,
                     unique=True,
                     list=True,
                     key=True,
+                    bind_to_schema=-1
                 ),
                 AttrDefSchema(
-                    attr_id=ages[1].id,
-                    required=True,
-                    unique=True,
-                    list=True,
-                    key=True,
-                )
-            ]
-        )
-        with pytest.raises(MultipleAttributeOccurencesException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
-        dbsession.rollback()
-
-
-        upd_schema = SchemaUpdateSchema(
-            name='Test', 
-            slug='test', 
-            update_attributes=[], 
-            add_attributes=[
-                AttrDefSchema(
-                    attr_id=ages[0].id,
-                    required=True,
-                    unique=True,
-                    list=True,
-                    key=True,
-                ),
-                AttrDefWithAttrDataSchema(
-                    name='age',
-                    type=AttrTypeMapping.FK,
+                    attr_id=address.id,
                     required=True,
                     unique=True,
                     list=True,
@@ -699,7 +692,35 @@ class TestSchemaUpdate:
             ]
         )
         with pytest.raises(MultipleAttributeOccurencesException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
+        dbsession.rollback()
+
+
+        upd_schema = SchemaUpdateSchema(
+            name='Test', 
+            slug='test', 
+            update_attributes=[], 
+            add_attributes=[
+                AttrDefSchema(
+                    attr_id=address.id,
+                    required=True,
+                    unique=True,
+                    list=True,
+                    key=True,
+                    bind_to_schema=-1
+                ),
+                AttrDefWithAttrDataSchema(
+                    name='address',
+                    type=AttrTypeMapping.DT,
+                    required=True,
+                    unique=True,
+                    list=True,
+                    key=True,
+                )
+            ]
+        )
+        with pytest.raises(MultipleAttributeOccurencesException):
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
    
 
 class TestSchemaDelete:

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -741,8 +741,9 @@ class TestSchemaUpdate:
    
 
 class TestSchemaDelete:
-    def test_delete(self, dbsession):
-        delete_schema(dbsession, schema_id=1)
+    @pytest.mark.parametrize('id_or_slug', [1, 'person'])
+    def test_delete(self, dbsession, id_or_slug):
+        delete_schema(dbsession, id_or_slug=id_or_slug)
 
         schemas = dbsession.execute(select(Schema)).scalars().all()
         assert len(schemas) == 1
@@ -751,15 +752,15 @@ class TestSchemaDelete:
         entities = dbsession.execute(select(Entity).where(Entity.schema_id == 1)).scalars().all()
         assert len(entities) == 2
         assert all([i.deleted for i in entities])
-
+    
     def test_raise_on_already_deleted(self, dbsession):
         dbsession.execute(update(Schema).where(Schema.id == 1).values(deleted=True))
         with pytest.raises(MissingSchemaException):
-            delete_schema(dbsession, schema_id=1)
+            delete_schema(dbsession, id_or_slug=1)
 
     def test_raise_on_delete_nonexistent(self, dbsession):
         with pytest.raises(MissingSchemaException):
-            delete_schema(dbsession, schema_id=999999999)
+            delete_schema(dbsession, id_or_slug=999999999)
 
     
 

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -357,7 +357,7 @@ class TestSchemaUpdate:
                 )
             ]
         )
-        update_schema(dbsession, schema_id=1, data=upd_schema)
+        update_schema(dbsession, id_or_slug='person', data=upd_schema)
 
         age_def = dbsession.execute(
             select(AttributeDefinition)
@@ -403,7 +403,7 @@ class TestSchemaUpdate:
             ], 
             add_attributes=[]
         )
-        update_schema(dbsession, schema_id=1, data=upd_schema)
+        update_schema(dbsession, id_or_slug=1, data=upd_schema)
 
         age_def = dbsession.execute(
             select(AttributeDefinition)
@@ -414,7 +414,7 @@ class TestSchemaUpdate:
         assert age_def is not None
         assert not any([age_def.required, age_def.unique, age_def.list, age_def.key])
 
-    def test_update_with_attr_data(self, dbsession):
+    def test_update_with_attr_data(self, dbsession, engine):
         attr = dbsession.execute(select(Attribute).where(Attribute.name == 'address')).scalar()
         attr_def = dbsession.execute(
             select(AttributeDefinition)
@@ -456,7 +456,7 @@ class TestSchemaUpdate:
                 )
             ]
         )
-        update_schema(dbsession, schema_id=1, data=upd_schema)
+        update_schema(dbsession, id_or_slug=1, data=upd_schema)
 
         address_def = dbsession.execute(
             select(AttributeDefinition)
@@ -501,7 +501,7 @@ class TestSchemaUpdate:
             add_attributes=[]
         )
         with pytest.raises(MissingSchemaException):
-            update_schema(dbsession, schema_id=99999999, data=upd_schema)
+            update_schema(dbsession, id_or_slug=99999999, data=upd_schema)
 
     def test_raise_on_existing_slug_or_name(self, dbsession):
         new_sch = Schema(name='Test', slug='test')
@@ -510,14 +510,14 @@ class TestSchemaUpdate:
         
         upd_schema = SchemaUpdateSchema(name='Person', slug='test', update_attributes=[], add_attributes=[])
         with pytest.raises(SchemaExistsException):
-            update_schema(dbsession, schema_id=new_sch.id, data=upd_schema)
+            update_schema(dbsession, id_or_slug=new_sch.id, data=upd_schema)
         dbsession.rollback()
         dbsession.add(new_sch)
         dbsession.flush()
 
         upd_schema = SchemaUpdateSchema(name='Test', slug='person', update_attributes=[], add_attributes=[])
         with pytest.raises(SchemaExistsException):
-            update_schema(dbsession, schema_id=new_sch.id, data=upd_schema)
+            update_schema(dbsession, id_or_slug=new_sch.id, data=upd_schema)
 
     def test_raise_on_attr_def_doesnt_exist(self, dbsession):
         upd_schema = SchemaUpdateSchema(
@@ -535,7 +535,7 @@ class TestSchemaUpdate:
             add_attributes=[]
         )
         with pytest.raises(AttributeNotDefinedException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
 
     def test_raise_on_convert_list_to_single(self, dbsession):
         attr = dbsession.execute(select(Attribute).where(Attribute.name == 'friends')).scalar()
@@ -559,7 +559,7 @@ class TestSchemaUpdate:
             add_attributes=[]
         )
         with pytest.raises(ListedToUnlistedException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
 
     def test_raise_on_attr_doesnt_exist(self, dbsession):
         upd_schema = SchemaUpdateSchema(
@@ -577,7 +577,7 @@ class TestSchemaUpdate:
             ]
         )
         with pytest.raises(MissingAttributeException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
 
     def test_raise_on_attr_def_already_exists(self, dbsession):
         attr = dbsession.execute(select(Attribute).where(Attribute.name == 'born')).scalar()
@@ -638,7 +638,7 @@ class TestSchemaUpdate:
             ]
         )
         with pytest.raises(MissingSchemaException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
 
     def test_raise_on_schema_not_passed_when_binding(self, dbsession):
         attr = dbsession.execute(
@@ -660,7 +660,7 @@ class TestSchemaUpdate:
             ]
         )
         with pytest.raises(NoSchemaToBindException):
-            update_schema(dbsession, schema_id=1, data=upd_schema)
+            update_schema(dbsession, id_or_slug=1, data=upd_schema)
 
     def test_raise_on_multiple_attrs_with_same_name(self, dbsession):
         address = dbsession.execute(

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -295,7 +295,7 @@ class TestSchemaUpdate:
             slug='test', 
             update_attributes=[
                 AttributeDefinitionUpdateSchema(
-                    id=attr_def.id,
+                    attr_def_id=attr_def.id,
                     required=False,
                     unique=False,
                     list=False,
@@ -344,6 +344,33 @@ class TestSchemaUpdate:
         sch = dbsession.execute(select(Schema).where(Schema.id == 1)).scalar()
         assert sch.name == 'Test' and sch.slug == 'test'
 
+    def test_update_attr_def_with_name(self, dbsession):
+        upd_schema = SchemaUpdateSchema(
+            name='Test', 
+            slug='test', 
+            update_attributes=[
+                AttributeDefinitionUpdateWithNameSchema(
+                    name='age',
+                    required=False,
+                    unique=False,
+                    list=False,
+                    key=False,
+                    description='Age of this person'
+                )
+            ], 
+            add_attributes=[]
+        )
+        update_schema(dbsession, schema_id=1, data=upd_schema)
+
+        age_def = dbsession.execute(
+            select(AttributeDefinition)
+            .join(Attribute)
+            .where(Attribute.name == 'age')
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        assert age_def is not None
+        assert not any([age_def.required, age_def.unique, age_def.list, age_def.key])
+
     def test_update_with_attr_data(self, dbsession):
         attr = dbsession.execute(select(Attribute).where(Attribute.name == 'address')).scalar()
         attr_def = dbsession.execute(
@@ -357,7 +384,7 @@ class TestSchemaUpdate:
             slug='test', 
             update_attributes=[
                 AttributeDefinitionUpdateSchema(
-                    id=attr_def.id,
+                    attr_def_id=attr_def.id,
                     required=False,
                     unique=False,
                     list=False,
@@ -455,8 +482,7 @@ class TestSchemaUpdate:
             slug='test', 
             update_attributes=[
                 AttributeDefinitionUpdateSchema(
-                    id=9999999,
-                    attr_id=1,
+                    attr_def_id=9999999,
                     required=True,
                     unique=True,
                     list=True,
@@ -480,8 +506,7 @@ class TestSchemaUpdate:
             slug='test', 
             update_attributes=[
                 AttributeDefinitionUpdateSchema(
-                    id=attr_def.id,
-                    attr_id=attr.id,
+                    attr_def_id=attr_def.id,
                     required=True,
                     unique=True,
                     list=False,

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -155,16 +155,18 @@ class TestRouteGetEntities:
 
     
     @pytest.mark.parametrize(['q', 'resp'], [
-        ('age=10',           ['jack']),
-        ('age.lt=10',        []),
-        ('age.eq=10',        ['jack']),
-        ('age.gt=10',        ['jane']),
-        ('age.le=10',        ['jack']),
-        ('age.ne=10',        ['jane']),
-        ('age.ge=10',        ['jack', 'jane']),
-        ('name=Jane',        ['jane']),
-        ('nickname=jane',    ['jane']),
-        ('nickname.ne=jack', ['jane']),
+        ('age=10',               ['jack']),
+        ('age.lt=10',            []),
+        ('age.eq=10',            ['jack']),
+        ('age.gt=10',            ['jane']),
+        ('age.le=10',            ['jack']),
+        ('age.ne=10',            ['jane']),
+        ('age.ge=10',            ['jack', 'jane']),
+        ('name=Jane',            ['jane']),
+        ('nickname=jane',        ['jane']),
+        ('nickname.ne=jack',     ['jane']),
+        ('nickname.regexp=^ja',  ['jack', 'jane']),
+        ('nickname.contains=ne', ['jane'])
     ])
     def test_get_with_filter(self, dbsession, client, request, q, resp):
         ents = [request.getfixturevalue(i) for i in resp]

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -39,7 +39,8 @@ class TestRouteGetEntity:
             'age': 10,
             'friends': [],
             'born': None,
-            'nickname': 'jack'
+            'nickname': 'jack',
+            'fav_color': ['red', 'blue']
         }
         response = client.get('/person/1')
         assert response.status_code == 200
@@ -121,7 +122,8 @@ class TestRouteGetEntities:
                 'id': 1, 
                 'deleted': False, 
                 'slug': 'Jack',
-                'name': 'Jack'
+                'name': 'Jack',
+                'fav_color': ['red', 'blue']
             }, 
             {
                 'age': 12, 
@@ -130,7 +132,8 @@ class TestRouteGetEntities:
                 'nickname': 'jane', 
                 'id': 2, 'deleted': False, 
                 'slug': 'Jane', 
-                'name': 'Jane'
+                'name': 'Jane',
+                'fav_color': ['red', 'black']
              }
         ]}
         response = client.get(f'/person?all_fields=True')
@@ -166,7 +169,9 @@ class TestRouteGetEntities:
         ('nickname=jane',        ['jane']),
         ('nickname.ne=jack',     ['jane']),
         ('nickname.regexp=^ja',  ['jack', 'jane']),
-        ('nickname.contains=ne', ['jane'])
+        ('nickname.contains=ne', ['jane']),
+        ('fav_color.eq=black',   ['jane']),
+        ('fav_color.ne=black',   ['jack', 'jane'])  # still returns both even though Jane has black fav_color, but also has red
     ])
     def test_get_with_filter(self, dbsession, client, request, q, resp):
         ents = [request.getfixturevalue(i) for i in resp]

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 from sqlalchemy import select, update
 
 from ..models import *
@@ -151,7 +152,7 @@ class TestRouteCreateEntity:
             'friends': [],
         }
         response = client.post(f'/person', json=p1)
-        assert response.json() == {'id': 3, 'slug': 'Mike', 'name': 'mike'}
+        assert response.json() == {'id': 3, 'slug': 'Mike', 'name': 'mike', 'deleted': False}
         
         mike = dbsession.execute(select(Entity).where(Entity.id == 3)).scalar()
         assert mike.get('nickname', dbsession).value == 'mike'
@@ -164,10 +165,10 @@ class TestRouteCreateEntity:
             'nickname': 'john',
             'age': 10,
             'friends': [3, 1],
-            'born': '2021-10-20T13:52:17'
+            'born': '2021-10-20T13:52:17',
         }
         response = client.post(f'/person', json=p2)
-        assert response.json() == {'id': 4, 'slug': 'John', 'name': 'john'}
+        assert response.json() == {'id': 4, 'slug': 'John', 'name': 'john', 'deleted': False}
 
         john = dbsession.execute(select(Entity).where(Entity.id == 4)).scalar()
         assert john.get('nickname', dbsession).value == 'john'
@@ -351,7 +352,7 @@ class TestRouteUpdateEntity:
         }
         response = client.put('person/1', json=data)
         assert response.status_code == 200
-        assert response.json() == {'id': 1, 'slug': 'test', 'name': 'test'}
+        assert response.json() == {'id': 1, 'slug': 'test', 'name': 'test', 'deleted': False}
 
         e = dbsession.execute(select(Entity).where(Entity.id == 1)).scalar()
         assert e.name == 'test'
@@ -373,7 +374,7 @@ class TestRouteUpdateEntity:
         }
         response = client.put('person/Jane', json=data)
         assert response.status_code == 200
-        assert response.json() == {'id': 2, 'slug': 'test2', 'name': 'Jane'}
+        assert response.json() == {'id': 2, 'slug': 'test2', 'name': 'Jane', 'deleted': False}
         
         e = dbsession.execute(select(Entity).where(Entity.id == 2)).scalar()
         assert e.slug == 'test2'

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -1,0 +1,470 @@
+from datetime import datetime
+
+from sqlalchemy import select, update
+
+from ..models import *
+from ..dynamic_routes import *
+from .. import load_schemas
+
+
+def test_load_schema_data(dbsession, client):
+    schemas = load_schemas()
+    assert len(schemas) == 1
+
+    s = schemas[0]
+    assert s.name == 'Person'
+
+
+def test_routes_were_generated(dbsession, client):
+    routes = [
+        '/person/{id_or_slug}',
+        '/person',
+        '/attributes',
+        '/attributes/{attr_id}',
+        '/schemas/{id_or_slug}',
+        '/schemas/{id_or_slug}',
+        '/schemas'
+    ]
+    assert all([i in [route.path for route in client.app.routes] for i in routes])
+
+
+class TestRouteGetEntity:
+    def test_get_entity(self, dbsession, client):
+        data = {
+            'id': 1,
+            'slug': 'Jack',
+            'deleted': False,
+            'age': 10,
+            'friends': [],
+            'born': None,
+            'nickname': 'jack'
+        }
+        response = client.get('/person/1')
+        assert response.status_code == 200
+        assert  response.json() == data
+
+        response = client.get(f'/person/Jack')
+        assert response.status_code == 200
+        assert  response.json() == data
+
+    def test_raise_on_entity_doesnt_exist(self, dbsession, client):
+        response = client.get('/person/99999999')
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_entity_doesnt_belong_to_schema(self, dbsession, client):
+        s = Schema(name='test', slug='test')
+        e = Entity(slug='test', schema=s)
+        dbsession.add_all([e, s])
+        dbsession.commit()
+        
+        response = client.get(f'/person/{e.id}')
+        assert response.status_code == 409
+        assert "doesn't belong to specified Schema" in response.json()['detail']
+
+class TestRouteGetEntities:
+    def test_get_entities(self, dbsession, client):
+        data = [
+            {'age': 10, 'id': 1, 'deleted': False, 'slug': 'Jack'}, 
+            {'age': 12, 'id': 2, 'deleted': False, 'slug': 'Jane'}
+        ]
+        response = client.get(f'/person/')
+        assert response.status_code == 200
+        assert response.json() == data
+
+    def test_get_deleted_only(self, dbsession, client):
+        dbsession.execute(update(Entity).where(Entity.id == 2).values(deleted=True))
+        dbsession.commit()
+
+        data = [{'age': 12, 'id': 2, 'deleted': True, 'slug': 'Jane'}]
+        response = client.get(f'/person?deleted_only=True')
+        assert response.status_code == 200
+        assert response.json() == data
+
+    def test_get_all(self, dbsession, client):
+        dbsession.execute(update(Entity).where(Entity.id == 2).values(deleted=True))
+        dbsession.commit()
+
+        data = [
+            {'age': 10, 'id': 1, 'deleted': False, 'slug': 'Jack'}, 
+            {'age': 12, 'id': 2, 'deleted': True, 'slug': 'Jane'}
+        ]
+        response = client.get(f'/person?all=True')
+        assert response.status_code == 200
+        assert response.json() == data
+
+        response = client.get(f'/person?all=True&deleted_only=True')
+        assert response.status_code == 200
+        assert response.json() == data
+
+    def test_get_all_fields(self, dbsession, client):
+        data = [
+            {
+                'age': 10, 
+                'born': None, 
+                'friends': [], 
+                'nickname': 'jack', 
+                'id': 1, 
+                'deleted': False, 
+                'slug': 'Jack'
+            }, 
+            {
+                'age': 12, 
+                'born': None, 
+                'friends': [1], 
+                'nickname': 'jane', 
+                'id': 2, 'deleted': False, 
+                'slug': 'Jane'
+             }
+        ]
+        response = client.get(f'/person?all_fields=True')
+        assert response.status_code == 200
+        assert response.json() == data
+
+    def test_offset_and_limit(self, dbsession, client):
+        jack = {'age': 10, 'id': 1, 'deleted': False, 'slug': 'Jack'}
+        jane = {'age': 12, 'id': 2, 'deleted': False, 'slug': 'Jane'}
+
+        response = client.get(f'/person?limit=1')
+        assert response.status_code == 200
+        assert response.json() == [jack]
+
+        response = client.get(f'/person?limit=1&offset=1')
+        assert response.status_code == 200
+        assert response.json() == [jane]
+
+        response = client.get(f'/person?offset=10')
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestRouteCreateEntity:
+    def test_create(self, dbsession, client):
+        p1 = {
+            'slug': 'Mike',
+            'nickname': 'mike',
+            'age': 10,
+            'friends': [],
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.json() == {'id': 3, 'slug': 'Mike'}
+        
+        mike = dbsession.execute(select(Entity).where(Entity.id == 3)).scalar()
+        assert mike.get('nickname', dbsession).value == 'mike'
+        assert mike.get('age', dbsession).value == 10
+        assert mike.get('friends', dbsession) == []
+
+        p2 = {
+            'slug': 'John',
+            'nickname': 'john',
+            'age': 10,
+            'friends': [3, 1],
+            'born': '2021-10-20T13:52:17'
+        }
+        response = client.post(f'/person', json=p2)
+        assert response.json() == {'id': 4, 'slug': 'John'}
+
+        john = dbsession.execute(select(Entity).where(Entity.id == 4)).scalar()
+        assert john.get('nickname', dbsession).value == 'john'
+        assert john.get('age', dbsession).value == 10
+        assert [i.value for i in john.get('friends', dbsession)] == [3, 1]
+        assert john.get('born', dbsession).value == datetime(2021, 10, 20, 13, 52, 17)
+
+    def test_raise_on_non_unique_slug(self, dbsession, client):
+        p1 = {
+            'slug': 'Jack', 
+            'nickname': 'test',
+            'age': 10,
+            'friends': []
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 409
+        assert 'already exists in this schema' in response.json()['detail']
+
+    def test_no_raise_on_same_slug_in_different_schemas(self, dbsession):
+        s = Schema(name='Test', slug='test')
+        dbsession.add(s)
+        dbsession.commit()
+
+        from .conftest import client_
+        client = client_(engine=dbsession.get_bind())
+
+        data = {'slug': 'Jack'}
+        response = client.post(f'/test', json=data)
+        assert response.status_code == 200
+
+    def test_raise_on_invalid_slug(self, dbsession, client):
+        p1 = {
+            'slug': '-Jake-', 
+            'nickname': 'jackie',
+            'age': 10,
+            'friends': []
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 422
+        assert 'is invalid value for slug field' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_non_unique_field(self, dbsession, client):
+        p1 = {
+            'slug': 'Jake', 
+            'nickname': 'jack',  # <-- already exists in db
+            'age': 10,
+            'friends': []
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 409
+        assert 'Got non-unique value for field' in response.json()['detail']
+
+    
+    def test_no_raise_on_non_unique_value_if_it_is_deleted(self, dbsession, client):
+        jacks = dbsession.execute(select(ValueStr).where(ValueStr.value == 'jack')).scalars().all()
+        assert len(jacks) == 1
+
+        dbsession.execute(update(Entity).where(Entity.id == 1).values(deleted=True))
+        dbsession.commit()
+        p1 = {
+            'slug': 'Jackie',  
+            'nickname': 'jack', # <-- already exists in db, but for deleted entity
+            'age': 10,
+            'friends': []
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 200
+
+    def test_raise_on_attr_doesnt_exist(self, dbsession, client):
+        p = {
+            'slug': 'SomeName',
+            'nickname': 'somename',
+            'age': 10,
+            'friends': [1],
+            'nonexistent': True
+        }
+        response = client.post(f'/person', json=p)
+        assert response.status_code == 422
+        assert 'extra fields not permitted' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_value_cast(self, dbsession, client):
+        p = {
+            'slug': 'SomeName',
+            'nickname': 'somename',
+            'age': 'INVALID VALUE',
+            'friends': [1],
+        }
+        response = client.post(f'/person', json=p)
+        assert response.status_code == 422
+        assert 'value is not a valid integer' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_passed_list_for_single_value_attr(self, dbsession, client):
+        p = {
+            'slug': 'Some name',
+            'nickname': 'somename',
+            'age': [1, 2, 3],
+            'friends': [1],
+        }
+        response = client.post(f'/person', json=p)
+        assert response.status_code == 422
+        assert 'value is not a valid integer' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_fk_entity_doesnt_exist(self, dbsession, client):
+        p1 = {
+            'slug': 'Mike',
+            'nickname': 'mike',
+            'age': 10,
+            'friends': [99999999]
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_fk_entity_is_deleted(self, dbsession, client):
+        dbsession.execute(update(Entity).where(Entity.id == 1).values(deleted=True))
+        dbsession.commit()
+        p1 = {
+            'slug': 'Mike',
+            'nickname': 'mike',
+            'age': 10,
+            'friends': [1]
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_fk_entity_from_wrong_schema(self, dbsession, client):
+        schema = Schema(name='Test', slug='test')
+        entity = Entity(schema=schema, slug='test')
+        dbsession.add_all([schema, entity])
+        dbsession.commit()
+
+        p1 = {
+            'slug': 'Mike',
+            'nickname': 'mike',
+            'age': 10,
+            'friends': [entity.id]
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 422
+        assert 'got instead entity' in response.json()['detail']
+        
+    def test_raise_on_slug_not_provided(self, dbsession, client):
+        p1 = {
+            'nickname': 'mike',
+            'age': 10,
+            'friends': [1]
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 422
+        assert 'field required' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_required_field_not_provided(self, dbsession, client):
+        p1 = {
+            'slug': 'Mike',
+            'friends': [1]
+        }
+        response = client.post(f'/person', json=p1)
+        assert response.status_code == 422
+        assert 'field required' in response.json()['detail'][0]['msg']
+
+    
+class TestRouteUpdateEntity:
+    def test_update(self, dbsession, client):
+        time = datetime.now()
+        data = {
+            'slug': 'test',
+            'nickname': None,
+            'born': '2021-10-20T13:52:17',
+            'friends': [1, 2],
+        }
+        response = client.put('person/1', json=data)
+        assert response.status_code == 200
+        assert response.json() == {'id': 1, 'slug': 'test'}
+
+        e = dbsession.execute(select(Entity).where(Entity.id == 1)).scalar()
+        assert e.slug == 'test'
+        assert e.get('age', dbsession).value == 10
+        assert e.get('born', dbsession).value == datetime(2021, 10, 20, 13, 52, 17)
+        assert [i.value for i in e.get('friends', dbsession)] == [1, 2]
+        assert e.get('nickname', dbsession) == None
+        nicknames = dbsession.execute(
+            select(ValueStr)
+            .where(Attribute.name == 'nickname')
+            .join(Attribute)
+        ).scalars().all()
+        assert len(nicknames) == 1, "nickname for entity 1 wasn't deleted from database"
+
+        data = {
+            'slug': 'test2',
+            'nickname': 'test'
+        }
+        response = client.put('person/Jane', json=data)
+        assert response.status_code == 200
+        assert response.json() == {'id': 2, 'slug': 'test2'}
+        
+        e = dbsession.execute(select(Entity).where(Entity.id == 2)).scalar()
+        assert e.slug == 'test2'
+        assert e.get('nickname', dbsession).value == 'test'
+        nicknames = dbsession.execute(
+            select(ValueStr)
+            .where(Attribute.name == 'nickname')
+            .join(Attribute)
+        ).scalars().all()
+        assert len(nicknames) == 1, "nickname for entity 2 wasn't deleted from database"
+
+    def test_raise_on_entity_doesnt_exist(self, dbsession, client):
+        response = client.put('person/99999999999', json={})
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+        response = client.put('person/qwertyuiop', json={})
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+        
+        s = Schema(name='test', slug='test')
+        e = Entity(slug='test', schema=s)
+        dbsession.add_all([s, e])
+        dbsession.commit()
+        response = client.put('person/test', json={})
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_schema_is_deleted(self, dbsession, client):
+        dbsession.execute(update(Schema).where(Schema.id == 1).values(deleted=True))
+        dbsession.commit()
+        response = client.put('person/1', json={})
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_entity_already_exists(self, dbsession, client):
+        data = {'slug': 'Jane'}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 409
+        assert 'already exists in this schema' in response.json()['detail']
+
+    def test_no_raise_on_changing_to_same_slug(self, dbsession, client):
+        data = {'slug': 'Jack'}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 200
+
+    def test_raise_on_attribute_not_defined_on_schema(self, dbsession, client):
+        data = {'not_existing_attr': 50000}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 422
+        assert 'extra fields not permitted' in response.json()['detail'][0]['msg']
+        
+        data = {'address': 1234}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 422
+        assert 'extra fields not permitted' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_invalid_slug(self, dbsession, client):
+        p1 = {
+            'slug': '-Jake-', 
+        }
+        response = client.put(f'/person/1', json=p1)
+        assert response.status_code == 422
+        assert 'is invalid value for slug field' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_deleting_required_value(self, dbsession, client):
+        data = {'age': None}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 422
+        assert 'Missing required field' in response.json()['detail']
+
+    def test_raise_on_passing_list_for_not_listed_attr(self, dbsession, client):
+        data = {'age': [1, 2, 3, 4, 5]}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 422
+        assert 'value is not a valid integer' in response.json()['detail'][0]['msg']
+
+    def test_raise_on_fk_entity_doesnt_exist(self, dbsession, client):
+        data = {'friends': [9999999999]}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_fk_entity_is_from_wrong_schema(self, dbsession, client):
+        s = Schema(name='test', slug='test')
+        e = Entity(slug='test', schema=s)
+        dbsession.add_all([s, e])
+        dbsession.commit()
+        
+        data = {'friends': [e.id]}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 422
+        assert "got instead entity" in response.json()['detail']
+
+    def test_raise_on_non_unique_value(self, dbsession, client):
+        data = {'nickname': 'jane'}
+        response = client.put('person/1', json=data)
+        assert response.status_code == 409
+        assert 'Got non-unique value' in response.json()['detail']
+
+    def test_no_raise_on_non_unique_if_existing_is_deleted(self, dbsession, client):
+        dbsession.execute(update(Entity).where(Entity.slug == 'Jane').values(deleted=True))
+        dbsession.commit()
+
+        data = {'nickname': 'jane'}
+        response = client.put('person/Jack', json=data)
+        assert response.status_code == 200
+        
+        e = dbsession.execute(select(Entity).where(Entity.slug == 'Jack')).scalar()
+        assert e.get('nickname', dbsession).value == 'jane'

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -214,11 +214,11 @@ class TestRouteGetEntities:
         response = client.get(f'/person?{q}')
         assert response.json()['entities'] == resp
 
-    def test_ignore_nonexistent_filter(self, dbsession, client, jack, jane):
+    def test_ignore_invalid_filter(self, dbsession, client, jack, jane):
         response = client.get('/person?age.gt=0&age.lt=20&qwe.rty=123')
         assert response.json()['entities'] == [jack, jane]
 
-        response = client.get('/person?age.gt=0&age.lt=20&age.qwe=1234')
+        response = client.get('/person?age.gt=0&age.lt=20&friends.lt=1234')
         assert response.json()['entities'] == [jack, jane]
 
         response = client.get('/person?age.qwe=1234')

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone, tzinfo
 
 import pytest
 from sqlalchemy import select, update
@@ -262,7 +262,7 @@ class TestRouteCreateEntity:
         assert john.get('nickname', dbsession).value == 'john'
         assert john.get('age', dbsession).value == 10
         assert [i.value for i in john.get('friends', dbsession)] == [3, 1]
-        assert john.get('born', dbsession).value == datetime(2021, 10, 20, 13, 52, 17)
+        assert john.get('born', dbsession).value == datetime(2021, 10, 20, 13, 52, 17, tzinfo=timezone.utc)
 
     def test_raise_on_non_unique_slug(self, dbsession, client):
         p1 = {
@@ -430,12 +430,11 @@ class TestRouteCreateEntity:
     
 class TestRouteUpdateEntity:
     def test_update(self, dbsession, client):
-        time = datetime.now()
         data = {
             'name': 'test',
             'slug': 'test',
             'nickname': None,
-            'born': '2021-10-20T13:52:17',
+            'born': '2021-10-20T13:52:17+03',
             'friends': [1, 2],
         }
         response = client.put('person/1', json=data)
@@ -446,7 +445,7 @@ class TestRouteUpdateEntity:
         assert e.name == 'test'
         assert e.slug == 'test'
         assert e.get('age', dbsession).value == 10
-        assert e.get('born', dbsession).value == datetime(2021, 10, 20, 13, 52, 17)
+        assert e.get('born', dbsession).value == datetime(2021, 10, 20, 10, 52, 17, tzinfo=timezone.utc)
         assert [i.value for i in e.get('friends', dbsession)] == [1, 2]
         assert e.get('nickname', dbsession) == None
         nicknames = dbsession.execute(

--- a/backend/tests/test_general_routes.py
+++ b/backend/tests/test_general_routes.py
@@ -540,6 +540,9 @@ class TestRouteSchemaUpdate:
         response = client.put('/schemas/1', json=data)
         assert response.status_code == 200
         assert response.json() == result
+        routes = [i.path for i in client.app.routes]
+        assert '/test' in routes
+        assert '/person' not in routes
 
         dbsession.expire_all()
         age_def = dbsession.execute(

--- a/backend/tests/test_general_routes.py
+++ b/backend/tests/test_general_routes.py
@@ -173,6 +173,8 @@ class TestRouteSchemaCreate:
         response = client.post('/schemas', json=data)
         assert response.status_code == 200
         assert response.json() == {'id': 2, 'name': 'Car', 'slug': 'car'}
+        assert '/car' in [i.path for i in client.app.routes]
+
 
         car = dbsession.execute(select(Schema).where(Schema.name == 'Car')).scalar()
         assert car is not None and car.id == 2 and car.slug == 'car'

--- a/backend/tests/test_general_routes.py
+++ b/backend/tests/test_general_routes.py
@@ -16,7 +16,8 @@ class TestRouteAttributes:
             {'id': 4, 'name': 'born', 'type': 'DT'},
             {'id': 5, 'name': 'friends', 'type': 'FK'},
             {'id': 6, 'name': 'address', 'type': 'FK'},
-            {'id': 7, 'name': 'nickname', 'type': 'STR'}
+            {'id': 7, 'name': 'nickname', 'type': 'STR'},
+            {'id': 8, 'name': 'fav_color', 'type': 'STR'}
         ]
         response = client.get('/attributes')
         assert response.json() == attrs
@@ -100,6 +101,15 @@ class TestRouteSchemasGet:
                  'required': False,
                  'type': 'STR',
                  'unique': True
+                 },
+                 {'bind_to_schema': None,
+                 'description': None,
+                 'key': False,
+                 'list': True,
+                 'name': 'fav_color',
+                 'required': False,
+                 'type': 'STR',
+                 'unique': False
                  }
             ],
             'deleted': False,
@@ -538,6 +548,16 @@ class TestRouteSchemaUpdate:
                 {
                     'bind_to_schema': None,
                     'description': None,
+                    'key': False,
+                    'list': True,
+                    'name': 'fav_color',
+                    'required': False,
+                    'type': 'STR',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
                     'key': True,
                     'list': True,
                     'name': 'address',
@@ -644,6 +664,16 @@ class TestRouteSchemaUpdate:
                     'required': False,
                     'type': 'STR',
                     'unique': True
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': True,
+                    'name': 'fav_color',
+                    'required': False,
+                    'type': 'STR',
+                    'unique': False
                 }
             ],
             'deleted': False,
@@ -753,6 +783,16 @@ class TestRouteSchemaUpdate:
                 {
                     'bind_to_schema': None,
                     'description': None,
+                    'key': False,
+                    'list': True,
+                    'name': 'fav_color',
+                    'required': False,
+                    'type': 'STR',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
                     'key': True,
                     'list': True,
                     'name': 'address',
@@ -761,7 +801,7 @@ class TestRouteSchemaUpdate:
                     'unique': False
                 },
                 {
-                        'bind_to_schema': None,
+                    'bind_to_schema': None,
                     'description': 'test',
                     'key': False,
                     'list': False,

--- a/backend/tests/test_general_routes.py
+++ b/backend/tests/test_general_routes.py
@@ -2,6 +2,8 @@ from typing import List
 
 from sqlalchemy import update
 
+from backend.crud import RESERVED_SCHEMA_SLUGS
+
 from ..models import *
 
 
@@ -268,6 +270,17 @@ class TestRouteSchemaCreate:
         assert all([attr_def.required, attr_def.unique, attr_def.key])
         assert not attr_def.list
         assert attr_def.description == 'Test 1'
+
+    def test_raise_on_reserved_slug(self, dbsession, client):
+        for i in RESERVED_SCHEMA_SLUGS:
+            data = {
+                'name': 'Person',
+                'slug': i,
+                'attributes': []
+            }
+            response = client.post('/schemas', json=data)
+            assert response.status_code == 409
+            assert "Can't create schema with slug" in response.json()['detail']
 
     def test_raise_on_duplicate_name_or_slug(self, dbsession, client):
         data = {
@@ -803,6 +816,17 @@ class TestRouteSchemaUpdate:
         ).scalar()
         assert bfk
 
+    def test_raise_on_reserved_slug(self, dbsession, client):
+        for i in RESERVED_SCHEMA_SLUGS:
+            data = {
+                'name': 'Person',
+                'slug': i,
+                'update_attributes': [],
+                'add_attributes': []
+            }
+            response = client.put('/schemas/1', json=data)
+            assert response.status_code == 409
+            assert "Can't create schema with slug" in response.json()['detail']
 
     def test_raise_on_schema_doesnt_exist(self, dbsession, client):
         data = {

--- a/backend/tests/test_general_routes.py
+++ b/backend/tests/test_general_routes.py
@@ -1,0 +1,1047 @@
+from typing import List
+
+from sqlalchemy import update
+
+from ..models import *
+
+
+class TestRouteAttributes:
+    def test_get_attributes(self, dbsession, client):
+        attrs = [
+            {'id': 1, 'name': 'age', 'type': 'FLOAT'},
+            {'id': 2, 'name': 'age', 'type': 'INT'},
+            {'id': 3, 'name': 'age', 'type': 'STR'},
+            {'id': 4, 'name': 'born', 'type': 'DT'},
+            {'id': 5, 'name': 'friends', 'type': 'FK'},
+            {'id': 6, 'name': 'address', 'type': 'FK'},
+            {'id': 7, 'name': 'nickname', 'type': 'STR'}
+        ]
+        response = client.get('/attributes')
+        assert response.json() == attrs
+
+    def test_get_attribute(self, dbsession, client):
+        response = client.get('/attributes/1')
+        assert response.json() == {'id': 1, 'name': 'age', 'type': 'FLOAT'}
+
+    def test_raise_on_attribute_doesnt_exist(self, dbsession, client):
+        response = client.get('/attributes/123456789')
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+class TestRouteSchemasGet:
+    def test_get_schemas(self, dbsession, client):
+        test = Schema(name='Test', slug='test', deleted=True)
+        dbsession.add(test)
+        dbsession.commit()
+
+        response = client.get('/schemas')
+        assert response.status_code == 200
+        assert response.json() == [{'id': 1, 'name': 'Person', 'slug': 'person'}]
+
+    def test_get_all(self, dbsession, client):
+        test = Schema(name='Test', slug='test', deleted=True)
+        dbsession.add(test)
+        dbsession.commit()
+
+        response = client.get('/schemas?all=True')
+        assert response.status_code == 200
+        assert response.json() == [{'id': 1, 'name': 'Person', 'slug': 'person'}, {'id': 2, 'name': 'Test', 'slug': 'test'}]
+
+        response = client.get('/schemas?all=True&deleted_only=True')
+        assert response.status_code == 200
+        assert response.json() == [{'id': 1, 'name': 'Person', 'slug': 'person'}, {'id': 2, 'name': 'Test', 'slug': 'test'}]
+
+    def test_get_deleted_only(self, dbsession, client):
+        test = Schema(name='Test', slug='test', deleted=True)
+        dbsession.add(test)
+        dbsession.commit()
+
+        response = client.get('/schemas?deleted_only=True')
+        assert response.status_code == 200
+        assert response.json() == [{'id': 2, 'name': 'Test', 'slug': 'test'}]
+
+    def test_get_schema(self, dbsession, client):
+        schema = {
+            'attributes': [
+                {'bind_to_schema': None,
+                 'description': 'Age of this person',
+                 'key': True,
+                 'list': False,
+                 'name': 'age',
+                 'required': True,
+                 'type': 'INT',
+                 'unique': False
+                },
+                {'bind_to_schema': None,
+                 'description': None,
+                 'key': False,
+                 'list': False,
+                 'name': 'born',
+                 'required': False,
+                 'type': 'DT',
+                 'unique': False
+                },
+                {'bind_to_schema': None,
+                 'description': None,
+                 'key': False,
+                 'list': True,
+                 'name': 'friends',
+                 'required': True,
+                 'type': 'FK',
+                 'unique': False
+                },
+                {'bind_to_schema': None,
+                 'description': None,
+                 'key': False,
+                 'list': False,
+                 'name': 'nickname',
+                 'required': False,
+                 'type': 'STR',
+                 'unique': True
+                 }
+            ],
+            'deleted': False,
+            'id': 1,
+            'name': 'Person',
+            'slug': 'person'
+        }
+
+        response = client.get('/schemas/1')
+        assert response.json() == schema
+
+        response = client.get('/schemas/person')
+        assert response.json() == schema
+
+    def test_raise_on_schema_doesnt_exist(self, dbsession, client):
+        response = client.get('/schemas/12345678')
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+        response = client.get('/schemas/qwertyui')
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+class TestRouteSchemaCreate:
+    def attrs(self, db: Session) -> List[Attribute]:
+        color = Attribute(name='color', type=AttrType.STR)
+        max_speed =  Attribute(name='max_speed', type=AttrType.INT)
+        release_year = Attribute(name='release_year', type=AttrType.DT)
+        owner = Attribute(name='owner', type=AttrType.FK)
+
+        db.add_all([color, max_speed, release_year, owner])
+        db.commit()
+        return [color, max_speed, release_year, owner]
+
+    def test_create(self, dbsession, client):
+        color, max_speed, release_year, owner = self.attrs(dbsession)
+        data = {
+            'name': 'Car',
+            'slug': 'car',
+            'attributes': [
+                {
+                    'attribute_id': color.id,   # this
+                    'required': False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'description': 'Color of this car'
+                },
+                {
+                    'attr_id': max_speed.id,  # and this are the same
+                    'required': True,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                },
+                {
+                    'attr_id': release_year.id,
+                    'required': False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                },
+                {
+                    'attr_id': owner.id,
+                    'required': True,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'bind_to_schema': 1
+                }
+            ]
+        }
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 200
+        assert response.json() == {'id': 2, 'name': 'Car', 'slug': 'car'}
+
+        car = dbsession.execute(select(Schema).where(Schema.name == 'Car')).scalar()
+        assert car is not None and car.id == 2 and car.slug == 'car'
+
+        attr_defs = dbsession.execute(select(AttributeDefinition).where(AttributeDefinition.schema_id == car.id)).scalars().all()
+        assert len(attr_defs) == 4
+
+        color_ = dbsession.execute(
+            select(AttributeDefinition)
+            .where(AttributeDefinition.schema_id == car.id)
+            .where(AttributeDefinition.attribute_id == color.id)
+        ).scalar()
+        assert not any([color_.required, color_.unique, color_.list, color_.key])
+        assert color_.description == 'Color of this car'
+
+        ry = dbsession.execute(
+            select(AttributeDefinition)
+            .where(AttributeDefinition.schema_id == car.id)
+            .where(AttributeDefinition.attribute_id == release_year.id)
+        ).scalar()
+        assert not any([ry.required, ry.unique, ry.list, ry.key])
+        assert ry.description is None
+
+        owner_ = dbsession.execute(
+            select(AttributeDefinition)
+            .where(AttributeDefinition.schema_id == car.id)
+            .where(AttributeDefinition.attribute_id == owner.id)
+        ).scalar()
+        bfk = dbsession.execute(select(BoundFK).where(BoundFK.attr_def_id == owner_.id)).scalars().all()
+        assert len(bfk) == 1 and bfk[0].schema.name == 'Person'
+
+    def test_create_with_attr_data(self, dbsession, client):
+        color, *_ = self.attrs(dbsession)
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'name': 'test1',
+                    'type': 'STR',
+                    'required': True,
+                    'unique': True,
+                    'list': False,
+                    'key': True,
+                    'description': 'Test 1'
+                },
+                {
+                    'name': 'test2',
+                    'type': 'STR',
+                    'required': True,
+                    'unique': True,
+                    'list': False,
+                    'key': True,
+                    'description': 'Test 2'
+                },
+                {
+                    'attribute_id': color.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'description': 'Color of this car'
+                }
+            ]
+        }
+
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 200
+        assert response.json() == {'id': 2, 'name': 'Test', 'slug': 'test'}
+
+        schemas = dbsession.execute(select(Schema)).scalars().all()
+        assert len(schemas) == 2
+
+        schema = dbsession.execute(select(Schema).where(Schema.name == 'Test')).scalar()
+        assert schema is not None
+        
+        attr = dbsession.execute(select(Attribute).where(Attribute.name == 'test1')).scalar()
+        assert attr is not None
+
+        attr2 = dbsession.execute(select(Attribute).where(Attribute.name == 'test2')).scalar()
+        assert attr2 is not None
+
+        attr_defs = dbsession.execute(
+            select(AttributeDefinition).where(AttributeDefinition.schema_id == schema.id)
+        ).scalars().all()
+        assert len(attr_defs) == 3
+
+        attr_def = attr_defs[0]
+        assert attr_def is not None
+        assert attr_def.attribute == attr
+        assert all([attr_def.required, attr_def.unique, attr_def.key])
+        assert not attr_def.list
+        assert attr_def.description == 'Test 1'
+
+    def test_raise_on_duplicate_name_or_slug(self, dbsession, client):
+        data = {
+            'name': 'Person',
+            'slug': 'test',
+            'attributes': []
+        }
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 409
+        assert 'already exists' in response.json()['detail']
+
+        data = {
+            'name': 'Test',
+            'slug': 'person',
+            'attributes': []
+        }
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 409
+        assert 'already exists' in response.json()['detail']
+
+    def test_raise_on_nonexistent_attr_id(self, dbsession, client):
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'attribute_id': 123456789,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'description': 'Nonexistent attribute'
+                }
+            ]
+        }
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_empty_schema_when_binding(self, dbsession, client):
+        *_, owner = self.attrs(dbsession)
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'attribute_id': owner.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 422
+        assert "You must bind attribute" in response.json()['detail']
+
+    def test_raise_on_nonexistent_schema_when_binding(self, dbsession, client):
+        *_, owner = self.attrs(dbsession)
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'attribute_id': owner.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'bind_to_schema': 123456789
+                }
+            ]
+        } 
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_passed_deleted_schema_for_binding(self, dbsession, client):
+        dbsession.execute(update(Schema).where(Schema.id == 1).values(deleted=True))
+        dbsession.commit()
+        *_, owner = self.attrs(dbsession)
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'attribute_id': owner.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'bind_to_schema': 1
+                }
+            ]
+        } 
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_multiple_attrs_with_same_name(self, dbsession, client):
+        color, *_ = self.attrs(dbsession)
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'name': 'test1',
+                    'type': 'STR',
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                },
+                {
+                    'name': 'test1',
+                    'type': 'INT',
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 409
+        assert "Found multiple occurrences of attribute" in response.json()['detail']
+
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'name': 'color',
+                    'type': 'INT',
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                },
+                {
+                    'attr_id': color.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 409
+        assert "Found multiple occurrences of attribute" in response.json()['detail']
+
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'attributes': [
+                {
+                    'attr_id': color.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                },
+                {
+                    'attr_id': color.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.post('/schemas', json=data)
+        assert response.status_code == 409
+        assert "Found multiple occurrences of attribute" in response.json()['detail']
+
+
+class TestRouteSchemaUpdate:
+    def test_update(self, dbsession, client):
+        address = dbsession.execute(select(Attribute).where(Attribute.name == 'address')).scalar()
+        age = dbsession.execute(
+            select(AttributeDefinition)
+            .join(Attribute)
+            .where(Attribute.name == 'age')
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [
+                {
+                    'attr_def_id': age.id,
+                    'required': False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'description': 'Age of this person'
+                }
+            ],
+            'add_attributes': [
+                {
+                    'attribute_id': address.id,
+                    'required': True,
+                    'unique': True,
+                    'list': True,
+                    'key': True,
+                    'bind_to_schema': -1
+                }
+            ]
+        } 
+        result = {
+            'attributes': [
+                {
+                    'bind_to_schema': None,
+                    'description': 'Age of this person',
+                    'key': False,
+                    'list': False,
+                    'name': 'age',
+                    'required': False,
+                    'type': 'INT',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': False,
+                    'name': 'born',
+                    'required': False,
+                    'type': 'DT',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': True,
+                    'name': 'friends',
+                    'required': True,
+                    'type': 'FK',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': False,
+                    'name': 'nickname',
+                    'required': False,
+                    'type': 'STR',
+                    'unique': True
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': True,
+                    'list': True,
+                    'name': 'address',
+                    'required': True,
+                    'type': 'FK',
+                    'unique': False
+                }
+            ],
+            'deleted': False,
+            'id': 1,
+            'name': 'Test',
+            'slug': 'test'
+        }
+
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 200
+        assert response.json() == result
+
+        dbsession.expire_all()
+        age_def = dbsession.execute(
+            select(AttributeDefinition)
+            .join(Attribute)
+            .where(Attribute.name == 'age')
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        assert age_def is not None
+        assert not any([age_def.required, age_def.unique, age_def.list, age_def.key])
+
+        address_def = dbsession.execute(
+            select(AttributeDefinition)
+            .where(AttributeDefinition.attribute_id == address.id)
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        assert address_def is not None
+        assert all([address_def.list, address_def.key, address_def.required])
+        assert not address_def.unique
+
+        bfk = dbsession.execute(
+            select(BoundFK)
+            .where(BoundFK.schema_id == 1)
+            .where(BoundFK.attr_def_id == address_def.id)
+        ).scalar()
+        assert bfk is not None
+
+        sch = dbsession.execute(select(Schema).where(Schema.id == 1)).scalar()
+        assert sch.name == 'Test' and sch.slug == 'test'
+
+    def test_update_attr_def_with_name(self, dbsession, client):
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [
+                {
+                    'name': 'age',
+                    'required': False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'description': 'Age of this person'
+                }
+            ],
+            'add_attributes': []
+        } 
+        result = {
+            'attributes': [
+                {
+                    'bind_to_schema': None,
+                    'description': 'Age of this person',
+                    'key': False,
+                    'list': False,
+                    'name': 'age',
+                    'required': False,
+                    'type': 'INT',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': False,
+                    'name': 'born',
+                    'required': False,
+                    'type': 'DT',
+                    'unique': False},
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': True,
+                    'name': 'friends',
+                    'required': True,
+                    'type': 'FK',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': False,
+                    'name': 'nickname',
+                    'required': False,
+                    'type': 'STR',
+                    'unique': True
+                }
+            ],
+            'deleted': False,
+            'id': 1,
+            'name': 'Test',
+            'slug': 'test'
+        }
+
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 200
+        assert response.json() == result
+
+
+        age_def = dbsession.execute(
+            select(AttributeDefinition)
+            .join(Attribute)
+            .where(Attribute.name == 'age')
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        assert age_def is not None
+        assert not any([age_def.required, age_def.unique, age_def.list, age_def.key])
+
+    def test_update_with_attr_data(self, dbsession, client):
+        address = dbsession.execute(select(Attribute).where(Attribute.name == 'address')).scalar()
+        age = dbsession.execute(
+            select(AttributeDefinition)
+            .join(Attribute)
+            .where(Attribute.name == 'age')
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [
+                {
+                    'attr_def_id': age.id,
+                    'required': False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'description': 'Age of this person'
+                }
+            ],
+            'add_attributes': [
+                {
+                    'attribute_id': address.id,
+                    'required': True,
+                    'unique': True,
+                    'list': True,
+                    'key': True,
+                    'bind_to_schema': -1
+                },
+                {
+                    'name': 'test',
+                    'type': 'FK',
+                    'required': False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'description': 'test',
+                    'bind_to_schema': -1
+                }
+            ]
+        } 
+        result = {
+            'attributes': [
+                {
+                    'bind_to_schema': None,
+                    'description': 'Age of this person',
+                    'key': False,
+                    'list': False,
+                    'name': 'age',
+                    'required': False,
+                    'type': 'INT',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': False,
+                    'name': 'born',
+                    'required': False,
+                    'type': 'DT',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': True,
+                    'name': 'friends',
+                    'required': True,
+                    'type': 'FK',
+                    'unique': False
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': False,
+                    'list': False,
+                    'name': 'nickname',
+                    'required': False,
+                    'type': 'STR',
+                    'unique': True
+                },
+                {
+                    'bind_to_schema': None,
+                    'description': None,
+                    'key': True,
+                    'list': True,
+                    'name': 'address',
+                    'required': True,
+                    'type': 'FK',
+                    'unique': False
+                },
+                {
+                        'bind_to_schema': None,
+                    'description': 'test',
+                    'key': False,
+                    'list': False,
+                    'name': 'test',
+                    'required': False,
+                    'type': 'FK',
+                    'unique': False
+                }
+            ],
+            'deleted': False,
+            'id': 1,
+            'name': 'Test',
+            'slug': 'test'
+        }
+
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 200
+        assert response.json() == result
+
+        dbsession.expire_all()
+        address_def = dbsession.execute(
+            select(AttributeDefinition)
+            .where(AttributeDefinition.attribute_id == address.id)
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        assert address_def is not None
+        assert not address_def.unique and address_def.list
+        age_def = dbsession.execute(
+            select(AttributeDefinition)
+            .join(Attribute)
+            .where(Attribute.name == 'age')
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        assert age_def is not None
+        assert not any([age_def.required, age_def.unique, age_def.list, age_def.key])
+        
+        sch = dbsession.execute(select(Schema).where(Schema.id == 1)).scalar()
+        assert sch.name == 'Test' and sch.slug == 'test'
+
+        test_def = dbsession.execute(
+            select(AttributeDefinition)
+            .join(Attribute)
+            .where(Attribute.name == 'test')
+            .where(AttributeDefinition.schema_id == 1)
+        ).scalar()
+        assert test_def is not None
+        assert test_def.attribute.type == AttrType.FK
+        bfk = dbsession.execute(
+            select(BoundFK)
+            .where(BoundFK.schema_id == 1)
+            .where(BoundFK.attr_def_id == test_def.id)
+        ).scalar()
+        assert bfk
+
+
+    def test_raise_on_schema_doesnt_exist(self, dbsession, client):
+        data = {
+            'name': 'Test',
+            'slug': 'person',
+            'update_attributes': [],
+            'add_attributes': []
+        }
+        response = client.put('/schemas/12345678', json=data)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_existing_slug_or_name(self, dbsession, client):
+        new_sch = Schema(name='Test', slug='test')
+        dbsession.add(new_sch)
+        dbsession.commit()
+        
+        data = {
+            'name': 'Test',
+            'slug': 'person',
+            'update_attributes': [],
+            'add_attributes': []
+        }
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 409
+        assert 'already exists' in response.json()['detail']
+
+        ata = {
+            'name': 'Person',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': []
+        }
+        response = client.put('/schemas/person', json=data)
+        assert response.status_code == 409
+        assert 'already exists' in response.json()['detail']
+
+    def test_raise_on_attr_def_doesnt_exist(self, dbsession, client):
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [
+                {
+                    'attr_def_id': 12345678,
+                    'required': True,
+                    'unique': True,
+                    'list': False,
+                    'key': True
+                }
+            ],
+            'add_attributes': []
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 404
+        assert "is not defined on schema" in response.json()['detail']
+
+    def test_raise_on_convert_list_to_single(self, dbsession, client):
+        attr_def = dbsession.execute(
+            select(AttributeDefinition)
+            .where(AttributeDefinition.schema_id == 1)
+            .join(Attribute)
+            .where(Attribute.name == 'friends')
+        ).scalar()
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [
+                {
+                    'attr_def_id': attr_def.id,
+                    'required': True,
+                    'unique': True,
+                    'list': False,
+                    'key': True
+                }
+            ],
+            'add_attributes': []
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 409
+        assert "is listed, can't make unlisted" in response.json()['detail']
+
+    def test_raise_on_attr_doesnt_exist(self, dbsession, client):
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': [
+                {
+                    'attr_id': 12345678,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+    
+    def test_raise_on_attr_def_already_exists(self, dbsession, client):
+        attr = dbsession.execute(select(Attribute).where(Attribute.name == 'born')).scalar()
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': [
+                {
+                    'attr_id': attr.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 409
+        assert "already defined" in response.json()['detail']
+
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': [
+                {
+                    'name': 'born',
+                    'type': 'STR',
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 409
+        assert "already defined" in response.json()['detail']
+
+
+    def test_raise_on_nonexistent_schema_when_binding(self, dbsession, client):
+        attr = dbsession.execute(
+            select(Attribute)
+            .where(Attribute.name == 'address')
+        ).scalar()
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': [
+                {
+                    'attr_id': attr.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'bind_to_schema': 123456789
+                }
+            ]
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 404
+        assert "doesn't exist or was deleted" in response.json()['detail']
+
+    def test_raise_on_schema_not_passed_when_binding(self, dbsession, client):
+        attr = dbsession.execute(
+            select(Attribute)
+            .where(Attribute.name == 'address')
+        ).scalar()
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': [
+                {
+                    'attr_id': attr.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                }
+            ]
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 422
+        assert "You must bind attribute" in response.json()['detail']
+
+    def test_raise_on_multiple_attrs_with_same_name(self, dbsession, client):
+        address = dbsession.execute(
+            select(Attribute)
+            .where(Attribute.name == 'address')
+        ).scalar()
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': [
+                {
+                    'attr_id': address.id,
+                    'type': 'STR',
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'bind_to_schema': -1
+                },
+                {
+                    'attribute_id': address.id,
+                    'type': 'INT',
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'bind_to_schema': -1
+                }
+            ]
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 409
+        assert "Found multiple occurrences of attribute" in response.json()['detail']
+
+        data = {
+            'name': 'Test',
+            'slug': 'test',
+            'update_attributes': [],
+            'add_attributes': [
+                {
+                    'name': 'address',
+                    'type': 'DT',
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                },
+                {
+                    'attr_id': address.id,
+                    'required':False,
+                    'unique': False,
+                    'list': False,
+                    'key': False,
+                    'bind_to_schema': -1
+                }
+            ]
+        } 
+        response = client.put('/schemas/1', json=data)
+        assert response.status_code == 409
+        assert "Found multiple occurrences of attribute" in response.json()['detail']

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -15,9 +15,9 @@ slugs = [
     ('hello-$-world', False),
     ('hello-456-world4', True),
     ('hello-456-wWorld', True),
-    ('456-hello', True),
-    ('456-World', True),
-    ('456', True)
+    ('456-hello', False),
+    ('456-World', False),
+    ('456', False)
 ]
 
 

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ..schemas import validate_slug
+
+
+slugs = [
+    ('hello', True),
+    ('Hello', True),
+    ('-', False),
+    ('hello-', False),
+    ('-hello', False),
+    ('-hello-', False),
+    ('hello-world', True),
+    ('hello---', False),
+    ('hello-$-world', False),
+    ('hello-456-world4', True),
+    ('hello-456-wWorld', True),
+    ('456-hello', True),
+    ('456-World', True),
+    ('456', True)
+]
+
+
+@pytest.mark.parametrize('test_input,is_valid', slugs)
+def test_validate_slug(test_input, is_valid):
+    if is_valid:
+        assert validate_slug(None, test_input) == test_input
+    else:
+        with pytest.raises(ValueError):
+            validate_slug(None, test_input)
+ 


### PR DESCRIPTION
Added some API routes to illustrate idea of how I see dynamic routes for schemas. The idea is that we have `create_dynamic_router()` (`dynamic_routes.py`) function that (given schema, FastAPI instance etc.) will create API routes for this schema. Routes are created at server start (`create_app()` in `__init__.py`) and when we create/update schema (currently `create_schema()` and `update_schema()` in `general_routes.py`). 

Routes logic is the same for all schemas, so main effect of `create_dynamic_router()` is to provide API documentation for these routes and dynamically generate input/output Pydantic models that are used for validation and API docs as well