### PR TITLE
Bugfix for backend container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,5 +6,4 @@ RUN pip3 install -r /opt/aimaas/requirements.txt; \
 
 WORKDIR /opt
 EXPOSE 8000
-ENV EXPOSED_HOST=localhost
-ENTRYPOINT uvicorn aimaas.main:app --port 8000 --host $EXPOSED_HOST
+ENTRYPOINT ["uvicorn", "aimaas.main:app", "--port", "8000", "--host", "localhost"]


### PR DESCRIPTION
Adjusted the `ENTRYPOINT` to allow passing of `--root-path`