### PR TITLE
Check that all required attributes are set (fixes #15)

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -659,7 +659,7 @@ def update_entity(db: Session, id_or_slug: Union[str, int], schema_id: int, data
     for model, req_attr_defs in groupby(non_updated_required_fields,
                                         lambda x: x.attribute.type.value[0]):
         expected_attr_ids = {attr_def.attribute_id for attr_def in req_attr_defs}
-        present_attr_ids = set(db.query(model.attribute_id)
+        present_attr_ids = set(aid[0] for aid in db.query(model.attribute_id)
                                  .filter(model.attribute_id.in_(expected_attr_ids),
                                          model.entity_id == e.id)
                                  .distinct())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -56,7 +56,7 @@ def populate_db(db: Session):
       -------|---------|----------|--------|------|----
       age    |    2    |     +    |   -    |   -  |  + 
       born   |    4    |     -    |   -    |   -  |  - 
-      friends|    5    |     +    |   -    |   +  |  - 
+      friends|    5    |     -    |   -    |   +  |  -
     nickname |    7    |     -    |   +    |   -  |  -
     fav_color|    8    |     -    |   -    |   +  |  -
 
@@ -116,7 +116,7 @@ def populate_db(db: Session):
     friends_ = AttributeDefinition(
         schema_id=person.id,
         attribute_id=friends.id,
-        required=True,
+        required=False,
         unique=False,
         list=True,
         key=False,

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -21,6 +21,7 @@ def asserts_after_entities_create(db: Session):
     assert [i.value for i in persons[-2].get('friends', db)] == [persons[-3].id, 1]
     assert persons[-1].get('born', db).value.astimezone(timezone.utc) == tz_born.astimezone(timezone.utc)
 
+
 class TestEntityCreate:
     def test_create(self, dbsession):
         born = datetime(1990, 6, 30, tzinfo=timezone.utc)

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -570,6 +570,7 @@ def asserts_after_entity_delete(db: Session):
     e = db.execute(select(Entity).where(Entity.id == 1)).scalar()
     assert e.deleted
 
+
 class TestEntityDelete:
     @pytest.mark.parametrize('id_or_slug', [1, 'Jack'])
     def test_delete(self, dbsession, id_or_slug):

--- a/backend/tests/test_traceability_schema.py
+++ b/backend/tests/test_traceability_schema.py
@@ -173,7 +173,7 @@ class TestUpdateSchema:
                 id=3,
                 name='friends',
                 type='FK',
-                required=True,
+                required=False,
                 unique=False,
                 list=True,
                 key=False,


### PR DESCRIPTION
It is allowed to convert an optional attribute to a required one. But after this change,
the CRUD function `update_entity` must check, whether all required attributes are really set.