### PR TITLE
Propagate data errors from database to clients (fixes #41)

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,7 +1,6 @@
-import typing
 from typing import Callable, Dict, Tuple
 from collections import defaultdict, Counter
-from itertools import chain, groupby
+from itertools import groupby
 
 from psycopg2.errors import ForeignKeyViolation
 from sqlalchemy import func, distinct, column, asc, desc, or_, select, update

--- a/backend/enum.py
+++ b/backend/enum.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, auto
 from typing import NamedTuple
 
 
@@ -20,3 +20,8 @@ class FilterEnum(Enum):
     STARTS = Filter('starts', 'startswith', 'starts with substring')
 
 
+class ModelVariant(Enum):
+    CREATE = auto()
+    GET = auto()
+    LIST = auto()
+    UPDATE = auto()

--- a/backend/schemas/entity.py
+++ b/backend/schemas/entity.py
@@ -1,9 +1,10 @@
 import re
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
-from pydantic import BaseModel, validator, Field
+from pydantic import BaseModel, validator, Field, create_model
 
-from ..models import Schema
+from ..enum import ModelVariant
+from ..models import Schema, AttributeDefinition
 
 
 def validate_slug(cls, slug: str):
@@ -48,3 +49,82 @@ class EntityListSchema(BaseModel):
 class FilterFields(BaseModel):
     operators: Dict[str, List[str]]
     fields: Dict[str, Dict[str, str]]
+
+
+class EntityModelFactory:
+    """
+    Create pydantic models dynamically based on schema definition
+    """
+    @staticmethod
+    def clean_fieldname(name: str) -> str:
+        """
+        Returns modified version of `name` if it shadows member of `pydantic.BaseModel`
+        """
+        if name in dir(BaseModel):
+            return name + '__'
+        return name
+
+    @staticmethod
+    def clean_modelname(name: str, variant: ModelVariant) -> str:
+        parts = re.split("[^a-z0-9]+", name, re.IGNORECASE)
+        return "".join(p.capitalize() for p in parts) + variant.name.capitalize()
+
+    @staticmethod
+    def fieldtype(attr_def: AttributeDefinition, optional: bool = False) -> tuple:
+        """
+        Given `AttributeDefinition` returns a type that will be for type annotations in Pydantic
+        model
+        """
+        kwargs = {'description': attr_def.description, 'alias': attr_def.attribute.name}
+        type_ = (attr_def.attribute.type  # AttributeDefinition.Attribute.type -> AttrType
+                .value.model  # AttrType.value -> Mapping, Mapping.model -> Value model
+                .value.property.columns[0].type.python_type)  # get python type of value column in Value child
+        if attr_def.list:
+            type_ = List[type_]
+        if not attr_def.required or optional:
+            type_ = Optional[type_]
+        return type_, Field(**kwargs)
+
+    def __call__(self, schema: Schema, variant: ModelVariant) -> type:
+        if variant is ModelVariant.LIST:
+            entity_model = self(schema=schema, variant=ModelVariant.GET)
+            return create_model(
+                self.clean_modelname(schema.slug, variant),
+                total=(int, Field(description='Total number of entities satisfying conditions')),
+                entities=(List[entity_model], Field(description='List of returned entities'))
+            )
+
+        class Config:
+            extra = 'forbid'
+
+        attr_fields = {
+            self.clean_fieldname(i.attribute.name): self.fieldtype(i,
+                                                                   variant != ModelVariant.CREATE)
+            for i in schema.attr_defs
+        }
+        entity_fields = {
+            "slug": (Optional[str] if variant is ModelVariant.UPDATE else str,
+                     Field(description='Slug of this entity')),
+            "name": (Optional[str] if variant is ModelVariant.UPDATE else str,
+                     Field(description='Name of this entity'))
+        }
+
+        if variant is ModelVariant.GET:
+            entity_fields.update({
+                'id': (int, Field(description='ID of this entity')),
+                'deleted': (bool, Field(description='Indicates whether this entity is marked as '
+                                                    'deleted')),
+            })
+
+        if variant == ModelVariant.UPDATE:
+            entity_fields.update()
+
+        return create_model(
+            self.clean_modelname(schema.slug, variant),
+            **entity_fields,
+            **attr_fields,
+            __config__=Config,
+            __validators__={
+                'slug_validator': validator('slug', allow_reuse=True)(validate_slug)
+            }
+        )

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -1,6 +1,7 @@
 from datetime import timezone, timedelta, datetime
 
 import pytest
+from sqlalchemy.exc import DataError
 
 from ..crud import *
 from ..models import *
@@ -227,6 +228,11 @@ class TestEntityCreate:
         }
         with pytest.raises(RequiredFieldException):
             create_entity(dbsession, schema_id=1, data=p1)
+
+    def test_raise_on_value_out_of_range(self, dbsession):
+        with pytest.raises(DataError):
+            create_entity(dbsession, schema_id=1, data={"name": "Frank", "slug": "frank",
+                                                        "age": 2147483648})
 
 
 class TestEntityRead:

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -496,6 +496,10 @@ class TestRouteUpdateEntity:
         e = dbsession.execute(select(Entity).where(Entity.slug == 'Jack')).scalar()
         assert e.get('nickname', dbsession).value == 'jane'
 
+    def test_raise_on_value_out_of_range(self, dbsession, authorized_client):
+        response = authorized_client.put('/entity/person/Jack', json={"age": 2147483648})
+        assert response.status_code == 422
+
 
 class TestRouteDeleteEntity:
     @pytest.mark.parametrize('entity', [1, 'Jack'])


### PR DESCRIPTION
Return an HTTP error 422 with a rudimentary explanation of
what went wrong instead of an HTTP error 500.

In addition, replaced almost identical definitions of dynamic
models with a factory.