### PR TITLE
Allow renaming of attributes in schema (fixes #61)

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -24,7 +24,6 @@ from .models import (
 
 from .schemas import (
     AttrDefSchema,
-    AttrTypeMapping,
     EntityBaseSchema,
     SchemaCreateSchema,
     SchemaUpdateSchema,
@@ -194,7 +193,8 @@ def _update_attr_in_schema(db: Session, attr_upd: AttrDefSchema, attr_def: Attri
         ValueModel = new_attr.type.value.model
         entity_ids = db.query(Entity.id).filter(Entity.schema_id == attr_def.schema_id).subquery()
         db.query(ValueModel)\
-            .filter(Entity.id.in_(entity_ids), ValueModel.attribute_id == attr_def.attribute_id)\
+            .filter(ValueModel.entity_id.in_(entity_ids),
+                    ValueModel.attribute_id == attr_def.attribute_id)\
             .update({"attribute_id": new_attr.id}, synchronize_session=False)
         attr_def.attribute = new_attr
 

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -6,8 +6,7 @@ from sqlalchemy.orm import Session
 from ..crud import create_schema, get_schema, get_schemas, update_schema, delete_schema, \
     get_entities, update_entity, get_entity
 from ..exceptions import SchemaExistsException, MissingSchemaException, RequiredFieldException, \
-    NoOpChangeException, ListedToUnlistedException, MultipleAttributeOccurencesException, \
-    InvalidAttributeChange
+    NoOpChangeException, ListedToUnlistedException, MultipleAttributeOccurencesException
 from ..models import Schema, AttributeDefinition, Attribute, AttrType, Entity
 from .. schemas import AttrDefSchema, SchemaCreateSchema, AttrTypeMapping, SchemaUpdateSchema
 


### PR DESCRIPTION
To create the illusion of renaming, the foreign key to the `Attribute` model
in the `AttributeDefinition` model gets replaced. When doing so, the foreign
keys to `Attribute` in the `Value*` models need to be updated as well.