### PR TITLE
Prevent any attempts to change the data type of an attribute

### DIFF
--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -134,21 +134,30 @@ class WrongSchemaToBindException(Exception):
     def __str__(self) -> str:
         return f'Attribute `{self.attr_name}` defined on schema ({self.schema_id}) is bound to schema ({self.bound_schema_id}); got instead entity ({self.passed_entity.id}) from schema ({self.passed_entity.schema_id})'
 
-class AttributeAlreadyDefinedException(Exception):
+
+class BaseAttributeException(Exception):
     def __init__(self, attr_id: int, schema_id: int):
         self.attr_id = attr_id
         self.schema_id = schema_id
 
+class AttributeAlreadyDefinedException(BaseAttributeException):
     def __str__(self) -> str:
-        return f'Attribute ({self.attr_id}) is already defined on schema ({self.schema_id})'
+        return f'Attribute ({self.attr_id}) is already defined on schema ({self.schema_id}).'
 
-class AttributeNotDefinedException(Exception):
-    def __init__(self, attr_id: int, schema_id: int):
-        self.attr_id = attr_id
-        self.schema_id = schema_id
+class AttributeNotDefinedException(BaseAttributeException):
+    def __str__(self) -> str:
+        return f'Attribute ({self.attr_id}) is not defined on schema ({self.schema_id}).'
+
+
+class InvalidAttributeChange(BaseAttributeException):
+    def __init__(self, attr_id: int, schema_id: int, field: str):
+        super().__init__(attr_id=attr_id, schema_id=schema_id)
+        self.field = field
 
     def __str__(self) -> str:
-        return f'Attribute with id {self.attr_id} is not defined on schema with id {self.schema_id}'
+        return f"Changing the field '{self.field}' of attribute ({self.attr_id}) on schema " \
+               f"({self.schema_id}) is not allowed."
+
 
 class ListedToUnlistedException(Exception):
     def __init__(self, attr_def_id: int):

--- a/backend/general_routes.py
+++ b/backend/general_routes.py
@@ -144,24 +144,16 @@ def update_schema(
         db.commit()
         create_dynamic_router(schema=schema, old_slug=old_slug, app=request.app)
         return schema
-    except exceptions.NoOpChangeException as e:
+    except (exceptions.NoOpChangeException, exceptions.NoSchemaToBindException) as e:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
-    except exceptions.MissingAttributeException as e:
+    except (exceptions.MissingAttributeException, exceptions.MissingSchemaException,
+            exceptions.AttributeNotDefinedException) as e:
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
-    except exceptions.MissingSchemaException as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
-    except exceptions.SchemaExistsException as e:
+    except (exceptions.SchemaExistsException, exceptions.ListedToUnlistedException,
+             exceptions.MultipleAttributeOccurencesException,
+            exceptions.AttributeAlreadyDefinedException,
+            exceptions.InvalidAttributeChange) as e:
         raise HTTPException(status.HTTP_409_CONFLICT, str(e))
-    except exceptions.AttributeNotDefinedException as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
-    except exceptions.ListedToUnlistedException as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, str(e))
-    except exceptions.MultipleAttributeOccurencesException as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, str(e))
-    except exceptions.AttributeAlreadyDefinedException as e:
-        raise HTTPException(status.HTTP_409_CONFLICT, str(e))
-    except exceptions.NoSchemaToBindException as e:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
 
 
 @router.delete(

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -6,7 +6,8 @@ from sqlalchemy.orm import Session
 from ..crud import create_schema, get_schema, get_schemas, update_schema, delete_schema, \
     get_entities, update_entity
 from ..exceptions import SchemaExistsException, MissingSchemaException, RequiredFieldException, \
-    NoOpChangeException, ListedToUnlistedException, MultipleAttributeOccurencesException
+    NoOpChangeException, ListedToUnlistedException, MultipleAttributeOccurencesException, \
+    InvalidAttributeChange
 from ..models import Schema, AttributeDefinition, Attribute, AttrType, Entity
 from .. schemas import AttrDefSchema, SchemaCreateSchema, AttrTypeMapping, SchemaUpdateSchema
 
@@ -369,6 +370,17 @@ class TestSchemaUpdate(DefaultMixin):
         ).scalar()
         assert nickname.attribute.type == AttrType.DT
         assert all([nickname.required, nickname.list, nickname.key])
+
+    def test_raise_on_attr_type_change(self, dbsession):
+        attrs = {a.name: a for a in self.get_default_attr_def_schemas(dbsession)}
+        nickname = attrs["nickname"]
+        nickname.type = "INT"
+
+        schema = self.get_default_schema(dbsession)
+        with pytest.raises(InvalidAttributeChange):
+            update_schema(dbsession, id_or_slug=schema.id, data=SchemaUpdateSchema(
+                attributes=list(attrs.values())
+            ))
 
     def test_raise_on_renaming_to_already_present_attr(self, dbsession):
         schema = self.get_default_schema(dbsession)

--- a/backend/tests/test_general_routes.py
+++ b/backend/tests/test_general_routes.py
@@ -394,6 +394,15 @@ class TestRouteSchemaUpdate(DefaultMixin):
         assert '/entity/test' in routes
         assert '/entity/person' not in routes
 
+    def test_raise_on_attr_type_change(self, dbsession: Session, authorized_client: TestClient):
+        attrs = {a["name"]: a for a in self.get_default_attr_def_dicts(dbsession)}
+        attrs["nickname"]["type"] = "INT"
+
+        schema = self.get_default_schema(dbsession)
+        response = authorized_client.put(f'/schema/{schema.id}',
+                                         json={"attributes": list(attrs.values())})
+        assert response.status_code == 409
+
     def test_raise_on_schema_doesnt_exist(self, dbsession, authorized_client):
         data = {
             'name': 'Test',

--- a/backend/tests/test_traceability_entity.py
+++ b/backend/tests/test_traceability_entity.py
@@ -374,7 +374,6 @@ class TestCreateEntityTraceability(DefaultMixin):
         change_request = self._create_request(dbsession=dbsession, user=testuser, data=data)
 
         change = entity_change_details(db=dbsession, change_request_id=change_request.id)
-        print("===DEBUG===", change.entity, *change.changes.items(), sep="\n - ")
         assert all(value.old is None
                    for key, value in change.changes.items()
                    if key != "schema_id" and not isinstance(data[key], list))

--- a/backend/traceability/entity.py
+++ b/backend/traceability/entity.py
@@ -135,8 +135,8 @@ def entity_change_details(db: Session, change_request_id: int) -> EntityChangeDe
         if attr_defs[attr_id].list:
             values = db.query(ValueModel).filter(ValueModel.id.in_([c.value_id for c in _changes]))
             change_["changes"][attr_name] = {
-                "new": [v.new_value for v in values if v.new_value],
-                "old": [v.old_value for v in values if v.old_value],
+                "new": sorted(v.new_value for v in values if v.new_value),
+                "old": sorted(v.old_value for v in values if v.old_value),
                 "current": get_old_value(db, entity, attr_name)
             }
         else:


### PR DESCRIPTION
The backend explicitly needs to check for attempts to change an attribute's type and complain
about it.