### PR TITLE
Do not accept no-op changes (fixes #91)

### DIFF
--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -243,6 +243,7 @@ def route_update_entity(router: APIRouter, schema: Schema):
         responses={
             200: {"description": "Entity was updated"},
             202: {"description": "Request to update entity was stored"},
+            208: {"description": "Entity was unchanged because request contained no changes"},
             404: {
                 'description': '''Can be returned when:
 
@@ -285,6 +286,8 @@ def route_update_entity(router: APIRouter, schema: Schema):
             db.commit()
             response.status_code = status.HTTP_202_ACCEPTED
             return change_request
+        except exceptions.NoOpChangeException as e:
+            raise HTTPException(status.HTTP_208_ALREADY_REPORTED, str(e))
         except (exceptions.MissingEntityException, exceptions.MissingSchemaException) as e:
             raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
         except (exceptions.EntityExistsException, exceptions.UniqueValueException) as e:

--- a/backend/tests/mixins.py
+++ b/backend/tests/mixins.py
@@ -11,23 +11,28 @@ from ..schemas.schema import AttrDefSchema
 
 
 class DefaultMixin:
+    _default_entity_slug = "Jack"
+    _default_schema_slug = "person"
+
     def get_default_schema(self, db: Session) -> Schema:
-        return db.query(Schema).filter(Schema.slug == "person").one()
+        return db.query(Schema).filter(Schema.slug == self._default_schema_slug).one()
 
     def get_default_entities(self, db: Session) -> typing.Dict[str, Entity]:
         return {e.slug: e
-                for e in db.query(Entity).join(Schema).filter(Schema.slug == "person").all()}
+                for e in db.query(Entity).join(Schema)
+                .filter(Schema.slug == self._default_schema_slug).all()}
 
     def get_default_entity(self, db: Session) -> Entity:
         return db.query(Entity)\
             .join(Schema)\
-            .filter(Schema.slug == "person", Entity.slug == "Jack")\
+            .filter(Schema.slug == self._default_schema_slug,
+                    Entity.slug == self._default_entity_slug)\
             .one()
 
     def get_default_attr_defs(self, db: Session) -> typing.List[AttributeDefinition]:
         return db.query(AttributeDefinition)\
             .join(Schema, Schema.id == AttributeDefinition.schema_id)\
-            .filter(Schema.slug == "person")\
+            .filter(Schema.slug == self._default_schema_slug)\
             .all()
 
     def get_default_attr_def_schemas(self, db: Session) -> typing.List[AttrDefSchema]:

--- a/backend/tests/test_crud_entity.py
+++ b/backend/tests/test_crud_entity.py
@@ -502,6 +502,24 @@ class TestEntityUpdate(DefaultMixin):
         update_entity(dbsession, id_or_slug='Jane', schema_id=entity.schema_id, data=data)
         self.asserts_after_entities_update(dbsession, born_time=time)
 
+    def test_no_changes(self, dbsession):
+        schema = self.get_default_schema(dbsession)
+        orig_entity = get_entity(db=dbsession, id_or_slug=self._default_entity_slug, schema=schema)
+        update_entity(
+            db=dbsession,
+            id_or_slug=orig_entity["id"],
+            schema_id=schema.id,
+            data={
+                "age": orig_entity["age"],
+                "born": orig_entity["born"],
+                "slug": orig_entity["slug"]
+            }
+        )
+        updated_entity = get_entity(db=dbsession, id_or_slug=self._default_entity_slug,
+                                    schema=schema)
+        for attr in ("age", "born", "nickname"):
+            assert orig_entity.get(attr, None) == updated_entity.get(attr, None)
+
     def test_no_raise_with_empty_optional_single_fk_field(self, dbsession):
         entity = self.get_default_entity(dbsession)
         attr = dbsession.execute(select(Attribute).where(Attribute.name == 'address')).scalar()
@@ -641,4 +659,3 @@ class TestEntityDelete(DefaultMixin):
         dbsession.flush()
         with pytest.raises(MissingEntityException):
             delete_entity(dbsession, id_or_slug=entity.id, schema_id=entity.schema_id)
-        

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -422,7 +422,7 @@ class TestRouteUpdateEntity(DefaultMixin):
         data = {'slug': 'Jack'}
         entity = self.get_default_entity(dbsession)
         response = authorized_client.put(f'/entity/person/{entity.id}', json=data)
-        assert response.status_code == 200
+        assert response.status_code == 208
 
     def test_raise_on_invalid_slug(self, dbsession, authorized_client):
         p1 = {
@@ -483,7 +483,7 @@ class TestRouteUpdateEntity(DefaultMixin):
         response = authorized_client.put('/entity/person/Jack', json={"age": 2147483648})
         assert response.status_code == 422
 
-    def test_raise_on_noop(self, dbsession, authorized_client):
+    def test_no_raise_on_missing_data(self, dbsession, authorized_client):
         response = authorized_client.put('/entity/person/Jack', json={})
         assert response.status_code == 208
 

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -483,6 +483,10 @@ class TestRouteUpdateEntity(DefaultMixin):
         response = authorized_client.put('/entity/person/Jack', json={"age": 2147483648})
         assert response.status_code == 422
 
+    def test_raise_on_noop(self, dbsession, authorized_client):
+        response = authorized_client.put('/entity/person/Jack', json={})
+        assert response.status_code == 208
+
 
 class TestRouteDeleteEntity(DefaultMixin):
     def test_delete(self, dbsession, authorized_client):

--- a/backend/tests/test_traceability_entity.py
+++ b/backend/tests/test_traceability_entity.py
@@ -159,6 +159,7 @@ class TestUpdateEntityTraceability(DefaultMixin):
 
     def test_list_change(self, dbsession: Session, testuser: User):
         entity = self.get_default_entities(dbsession)["Jane"]
+        entity_data = get_entity(dbsession, "Jane", self.get_default_schema(dbsession))
         change_request = create_entity_update_request(dbsession, entity.id, entity.schema_id,
                                                       {"friends": self._default_friends(dbsession)},
                                                       testuser)
@@ -167,8 +168,8 @@ class TestUpdateEntityTraceability(DefaultMixin):
         friends = self._default_friends(dbsession)
         assert details.changes["friends"].dict() == {
             'new': friends,
-            'old': friends[:1],
-            'current': friends[:1]}
+            'old': entity_data["friends"],
+            'current': entity_data["friends"]}
 
         apply_entity_update_request(dbsession, change_request=change_request, reviewed_by=testuser,
                                     comment="Test")

--- a/backend/traceability/entity.py
+++ b/backend/traceability/entity.py
@@ -15,7 +15,7 @@ from ..auth.models import User
 from ..config import DEFAULT_PARAMS
 from ..enum import ModelVariant
 from ..exceptions import MissingChangeException, MissingEntityCreateRequestException, \
-    AttributeNotDefinedException, MissingEntityUpdateRequestException, \
+    AttributeNotDefinedException, MissingEntityUpdateRequestException, NoOpChangeException, \
     MissingEntityDeleteRequestException, MissingChangeRequestException
 from ..models import Entity, AttributeDefinition, Schema, Attribute
 from ..schemas.entity import EntityModelFactory
@@ -155,8 +155,9 @@ def get_old_value(db: Session, entity: Entity, attr_name: str) -> List[Any]:
 
 
 def _create_value_changes(db: Session, change_request: ChangeRequest, schema: Schema, data: dict,
-                          entity: Optional[Entity] = None, new: bool = False):
+                          entity: Optional[Entity] = None, new: bool = False) -> bool:
     attr_defs: Dict[str, AttributeDefinition] = {i.attribute.name: i for i in schema.attr_defs}
+    changes_present = False
     for field, value in data.items():
         attr_def = attr_defs.get(field)
         attr: Attribute = attr_def.attribute
@@ -165,6 +166,9 @@ def _create_value_changes(db: Session, change_request: ChangeRequest, schema: Sc
         new_values = crud._convert_values(attr_def=attr_def, value=value, caster=caster) or []
         old_values = [] if new else get_old_value(db=db, entity=entity, attr_name=attr.name)
         for new_val, old_val in zip_longest(sorted(new_values), sorted(old_values), fillvalue=None):
+            if old_val == new_val:
+                continue
+            changes_present = True
             v = model(new_value=new_val, old_value=old_val)
             db.add(v)
             db.flush()
@@ -179,6 +183,7 @@ def _create_value_changes(db: Session, change_request: ChangeRequest, schema: Sc
             )
             db.add(change)
             db.flush()
+    return changes_present
 
 
 def create_entity_create_request(db: Session, data: dict, schema_id: int, created_by: User,
@@ -366,8 +371,13 @@ def create_entity_update_request(
     
     entity_fields = {'name': data.pop('name', None), 'slug': data.pop('slug', None)}
     entity_fields = {k: v for k, v in entity_fields.items() if v is not None}
+    changes_present = False
     for field, value in entity_fields.items():
-        v = ChangeValueStr(old_value=getattr(entity, field), new_value=value)
+        old_value = getattr(entity, field)
+        if old_value == value:
+            continue
+        changes_present = True
+        v = ChangeValueStr(old_value=old_value, new_value=value)
         db.add(v)
         db.flush()
         change = Change(
@@ -382,8 +392,10 @@ def create_entity_update_request(
         db.add(change)
 
     schema = db.query(Schema).get(schema_id)
-    _create_value_changes(db=db, change_request=change_request, schema=schema, data=data, new=False,
-                          entity=entity)
+    changes_present &= _create_value_changes(db=db, change_request=change_request, schema=schema,
+                                             data=data, new=False, entity=entity)
+    if not changes_present:
+        raise NoOpChangeException("Change request contains no changes")
     if commit:
         db.commit()
     else:


### PR DESCRIPTION
* Raise `NoOpChangeException` when a change request would contain no changes
* Reply with status 208 via the API, if an entity does not get changed
* Do not log no-op changes
* Extended tests