### PR TITLE
Bugfix for permission management of entities

### DIFF
--- a/backend/dynamic_routes.py
+++ b/backend/dynamic_routes.py
@@ -166,7 +166,7 @@ def route_get_entities(router: APIRouter, schema: Schema):
 
 def route_create_entity(router: APIRouter, schema: Schema):
     req_permission = authenticated_user
-    if schema.reviewable:
+    if not schema.reviewable:
         req_permission = authorized_user(RequirePermission(
             permission=PermissionType.CREATE_ENTITY,
             target=Schema()
@@ -229,7 +229,7 @@ def route_create_entity(router: APIRouter, schema: Schema):
 
 def route_update_entity(router: APIRouter, schema: Schema):
     req_permission = authenticated_user
-    if schema.reviewable:
+    if not schema.reviewable:
         req_permission = authorized_user(RequirePermission(
             permission=PermissionType.UPDATE_ENTITY,
             target=Entity()
@@ -300,7 +300,7 @@ def route_update_entity(router: APIRouter, schema: Schema):
 
 def route_delete_entity(router: APIRouter, schema: Schema):
     req_permission = authenticated_user
-    if schema.reviewable:
+    if not schema.reviewable:
         req_permission = authorized_user(RequirePermission(
             permission=PermissionType.DELETE_ENTITY,
             target=Entity()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from ..auth import authenticated_user, authorized_user
 from ..auth.crud import get_or_create_user, get_user, grant_permission
 from ..auth.enum import RecipientType, PermissionType
-from ..auth.models import User
+from ..auth.models import User, Permission
 from ..database import get_db
 from ..models import *
 from ..schemas.auth import UserCreateSchema, PermissionSchema
@@ -351,6 +351,22 @@ class OldStyleTestClient(TestClient):
             extensions=extensions,
             json=json
         )
+
+
+@pytest.fixture
+def unauthorized_testuser(dbsession, testuser) -> User:
+    # The testuser is a superuser. Remove permissions.
+    dbsession.query(Permission).filter(Permission.recipient_type == RecipientType.USER,
+                                       Permission.recipient_id == testuser.id).delete()
+    return testuser
+
+
+@pytest.fixture
+def unauthorized_testuser(dbsession, testuser) -> User:
+    # The testuser is a superuser. Remove permissions.
+    dbsession.query(Permission).filter(Permission.recipient_type == RecipientType.USER,
+                                       Permission.recipient_id == testuser.id).delete()
+    return testuser
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -362,14 +362,6 @@ def unauthorized_testuser(dbsession, testuser) -> User:
 
 
 @pytest.fixture
-def unauthorized_testuser(dbsession, testuser) -> User:
-    # The testuser is a superuser. Remove permissions.
-    dbsession.query(Permission).filter(Permission.recipient_type == RecipientType.USER,
-                                       Permission.recipient_id == testuser.id).delete()
-    return testuser
-
-
-@pytest.fixture
 def client(dbsession):
     app = create_app(session=dbsession)
     app.dependency_overrides[get_db] = lambda: dbsession

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -395,6 +395,9 @@ class TestRoutesRequiringAuth:
 
     def test_approve_request(self, dbsession: Session, unauthorized_testuser: User,
                              authenticated_client: TestClient):
+        """
+        Test that an authenticated but unauthorized user is not allowed to approve a change request.
+        """
         change_request_ids = dbsession.query(ChangeRequest.id)\
             .where(ChangeRequest.status == ChangeStatus.PENDING)\
             .first()

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -411,7 +411,7 @@ class TestRoutesRequiringAuth:
                                                     unauthorized_testuser: User,
                                                     authenticated_client: TestClient):
         """
-        Test that authenticated user is allowed to create a change request without actually changing
+        Test that authenticated user is allowed to update a change request without actually changing
         an entity
         """
         schema = dbsession.query(Schema).where(Schema.slug == "unperson").one()
@@ -429,7 +429,7 @@ class TestRoutesRequiringAuth:
                                                     unauthorized_testuser: User,
                                                     authenticated_client: TestClient):
         """
-        Test that authenticated user is allowed to create a change request without actually deleting
+        Test that authenticated user is allowed to delete a change request without actually deleting
         an entity
         """
         schema = dbsession.query(Schema).where(Schema.slug == "unperson").one()


### PR DESCRIPTION
A small bug allowed authenticated users to perform any actions on entities without permission, when the `reviewable` flag of the schema was unset. On the flip side, it prevented them from creating change requests for entities they had no permissions on.

This change fixes the situation:

* Any authenticated user is allowed to create change requests
* Only authorized users are allowed to apply changes to entities