### PR TITLE
Overload TestClient.delete to accept JSON data again

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ python-dotenv
 python-jose[cryptography]
 python-multipart
 SQLAlchemy
+starlette
 uvicorn

--- a/backend/requirements_test.txt
+++ b/backend/requirements_test.txt
@@ -1,3 +1,5 @@
+# See: https://github.com/encode/starlette/issues/1943
+httpx
 pytest
 pytest-cov
 pytest-mock==3.6.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone, timedelta
 
 from alembic import command
 from alembic.config import Config
+from httpx._client import USE_CLIENT_DEFAULT
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -333,11 +334,31 @@ def testuser(dbsession) -> User:
     return get_user(db=dbsession, username=TEST_USER.username)
 
 
+class OldStyleTestClient(TestClient):
+    def delete(self, url, *, params=None, headers=None, cookies=None, auth=USE_CLIENT_DEFAULT,
+               follow_redirects=None, allow_redirects=None, timeout=USE_CLIENT_DEFAULT,
+               extensions=None, json=None):
+        # Note: Since starlette 0.21 `TestClient.delete` no longer accepts the `json` parameter.
+        return self.request(
+            "DELETE",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            allow_redirects=allow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+            json=json
+        )
+
+
 @pytest.fixture
 def client(dbsession):
     app = create_app(session=dbsession)
     app.dependency_overrides[get_db] = lambda: dbsession
-    client = TestClient(app)
+    client = OldStyleTestClient(app)
     yield client
 
 

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone, timedelta
 
 import pytest
-from sqlalchemy import update
 
 from ..models import *
 from ..dynamic_routes import *
@@ -13,10 +12,7 @@ from .mixins import DefaultMixin
 class TestRouteBasics:
     def test_load_schema_data(self, dbsession, client):
         schemas = load_schemas(db=dbsession)
-        assert len(schemas) == 2
-
-        s = schemas[0]
-        assert s.name == 'Person'
+        assert {s.name for s in schemas} == {'Person', 'UnPerson'}
 
     def test_routes_were_generated(self, dbsession, client):
         routes = [


### PR DESCRIPTION
Starting from version 0.21 the `TestClient` in starlette
is based on `httpx`, which does not accept a `json` parameter
for its `delete` method.

Motivation: AIMAAS expects a request body for some DELETE requests.