### PR TITLE
Freeze package version

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,5 +9,5 @@ pydantic<1.9.1
 python-dotenv
 python-jose[cryptography]
 python-multipart
-SQLAlchemy
+SQLAlchemy<2
 uvicorn


### PR DESCRIPTION
SQLAlchemy v2 is not supported, yet. Therefore we freeze its version.