### PR TITLE
Move alert display to top of screen and enlarge text

### DIFF
--- a/frontend/src/components/alerts/AlertDisplay.vue
+++ b/frontend/src/components/alerts/AlertDisplay.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container-fluid fixed-bottom m-3 d-flex flex-column align-items-end"
-       id="alert-contaier">
+       id="alert-container">
       <div v-for="alert of alerts" :key="alert.id"
            class="alert shadow alert-dismissible fade show w-50 me-3"
            :class="`alert-${alert.level}`" role="alert">
@@ -58,7 +58,7 @@ export default {
 </script>
 
 <style scoped>
-#alert-contaier {
+#alert-container {
   z-index: 10;
 }
 </style>

--- a/frontend/src/components/alerts/AlertDisplay.vue
+++ b/frontend/src/components/alerts/AlertDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container-fluid fixed-bottom m-3 d-flex flex-column align-items-end"
+  <div class="container-fluid fixed-top m-3 d-flex flex-column align-items-end fs-4"
        id="alert-container">
       <div v-for="alert of alerts" :key="alert.id"
            class="alert shadow alert-dismissible fade show w-50 me-3"


### PR DESCRIPTION
Regarding [Issue 98](https://github.com/SUSE/aimaas/issues/98)
This PR enhances alert visibility by moving the alert display from the bottom right to the top right corner of the screen and enlarging the text displayed within alerts by 50%.