### PR TITLE
Add dynamic window titles (from #75)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -48,8 +48,12 @@ import AlertDisplay from "@/components/alerts/AlertDisplay";
 import HelpNav from "@/components/help/HelpNav";
 import SchemaList from "@/components/SchemaList";
 import ReviewNav from "@/components/change_review/ReviewNav";
+import usePageTitle from '@/composables/usePageTitle';
 
 export default {
+  setup(){
+    usePageTitle();
+  },
   name: 'App',
   components: {SchemaList, AlertDisplay, AuthNav, ReviewNav, HelpNav},
   data: function () {

--- a/frontend/src/components/Entity.vue
+++ b/frontend/src/components/Entity.vue
@@ -99,6 +99,11 @@ export default {
     await this.updateEntity();
   },
   watch: {
+    entity(newValue) {
+      if (newValue?.name) {
+        document.title = newValue.name;
+      }
+    }, 
     async "$route.params.entitySlug"() {
       await this.updateEntity();
     },

--- a/frontend/src/components/Schema.vue
+++ b/frontend/src/components/Schema.vue
@@ -86,6 +86,11 @@ export default {
         return "n/a";
       }
     }
+  },
+  updated() {
+    if (this.activeSchema?.name) {
+        document.title = this.activeSchema.name;
+      }
   }
 }
 </script>

--- a/frontend/src/composables/usePageTitle.js
+++ b/frontend/src/composables/usePageTitle.js
@@ -1,0 +1,18 @@
+import { ref, onMounted, watch } from 'vue';
+import { useRoute } from 'vue-router';
+
+export default function usePageTitle(pageTitle) {
+  const defaultTitle = "AIMAAS"; // used when no title is defined for given route
+  const route = useRoute();
+  const title = ref(defaultTitle);
+
+  onMounted(() => { // used on first load to DOM
+    title.value = pageTitle || route.meta.title || defaultTitle;
+    document.title = title.value;
+  });
+
+  watch(() => route.meta.title, () => { // allows reactive changes
+    title.value = pageTitle || route.meta.title || defaultTitle;
+    document.title = title.value;
+  });
+}

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -13,37 +13,58 @@ export const router = createRouter({
         {
             path: '/createSchema',
             component: SchemaCreate,
-            name: 'schema-new'
+            name: 'schema-new',
+            meta: {
+                title: 'Create Schema'
+            }
         },
         {
             path: '/schema/:schemaSlug',
             component: Schema,
-            name: 'schema-view'
+            name: 'schema-view',
+            meta: {
+                title: 'Schema Details'
+            }
         },
         {
             path: '/schema/:schemaSlug/:entitySlug',
             component: Entity,
-            name: 'entity-view'
+            name: 'entity-view',
+            meta: {
+                title: 'Entity Details'
+            }
         },
         {
           path: '/review',
           component: Changes,
-          name: 'review-list'
+          name: 'review-list',
+          meta: {
+            title: 'Pending Reviews'
+        }
         },
         {
             path: '/user-management',
             component: AuthManager,
-            name: 'auth-manager'
+            name: 'auth-manager',
+            meta: {
+                title: 'User Management'
+            }
         },
         {
             path: '/',
             component: SchemaList,
-            name: 'schema-list'
+            name: 'schema-list',
+            meta: {
+                title: 'All Schemas'
+            }
         },
         {
             path: '/help/about',
             component: About,
-            name: 'help-about'
+            name: 'help-about',
+            meta: {
+                title: 'About AIMAAS'
+            }
         }
     ],
 });


### PR DESCRIPTION
**WIP**
as discussed in #75, this PR adds a `usePageTitle.js` composable which allows for dynamic and reactive window titles, also checks the routes meta information (defined in `router.js`) for predefined `meta.title` variables and uses these if no dynamic title was passed. If no explicit title was passed nor found within the router.js routes definitions, the default title `AIMAAS` is used instead