### PR TITLE
Fixed stale references on array with selected entities

### DIFF
--- a/frontend/src/components/EntityList.vue
+++ b/frontend/src/components/EntityList.vue
@@ -86,9 +86,10 @@ export default {
       await this.getEntities({resetPage: true});
     },
     async getEntities({resetPage = false} = {}) {
+      this.selected.length = 0;
+
       if (resetPage) {
         this.currentPage = 1;
-        this.selected = [];
       }
       this.loading = true;
       if (!this.schema) {


### PR DESCRIPTION
When a new page with entity data is loaded the `getEntities` assigns a new Arrays to its `selected` attribute, which breaks existing references.

Also, the selection should be cleared. However, in the future somebody might prefer to support selections across multiple pages; but not for now.