### PR TITLE
added configurable timeout to the `_fetch` function #138

### DIFF
--- a/frontend/src/plugins/api.js
+++ b/frontend/src/plugins/api.js
@@ -89,7 +89,7 @@ class API {
         }
     }
 
-    async _fetch({url, headers, body, method} = {}) {
+    async _fetch({url, headers, body, method, timeout = 10000} = {}) {
         let allheaders = {"Content-Type": "application/json"};
         const token = this.token;
         if (token) {
@@ -104,11 +104,17 @@ class API {
         }
 
         try {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), timeout);
+
             const response = await fetch(url, {
                 method: method || 'GET',
                 body: encoded_body,
-                headers: allheaders
+                headers: allheaders,
+                signal: controller.signal
             });
+
+            clearTimeout(timeout);
             await this._is_response_ok(response);
             return await response.json();
         } catch (e) {


### PR DESCRIPTION
this merge request adds a configurable timeout to the `_fetch` function in `api.js`. by default, the function now uses a timeout of 10 seconds, as suggested in the issue, and also seems to be more appropriate for most requests. the timeout can be overridden by passing a timeout parameter to the function.

this change addresses issue #138, which requested that the fetch calls should time out more quickly. the change makes the code more flexible and allows it to be used in a wider range of scenarios.

please review and merge this change if it meets the project's standards.