### PR TITLE
Raise `MissingObjectException` in `get_entity_model`

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -533,7 +533,7 @@ def get_entity_by_id(db: Session, entity_id: int) -> Entity:
     return entity
 
 
-def get_entity_model(db: Session, id_or_slug: Union[int, str], schema: Schema) -> Optional[Entity]:
+def get_entity_model(db: Session, id_or_slug: Union[int, str], schema: Schema) -> Entity:
     q = select(Entity).where(Entity.schema_id == schema.id)
     if isinstance(id_or_slug, int):
         filter = Entity.id == id_or_slug

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -536,17 +536,17 @@ def get_entity_by_id(db: Session, entity_id: int) -> Entity:
 def get_entity_model(db: Session, id_or_slug: Union[int, str], schema: Schema) -> Optional[Entity]:
     q = select(Entity).where(Entity.schema_id == schema.id)
     if isinstance(id_or_slug, int):
-        return db.execute(q.where(Entity.id == id_or_slug)).scalar()
+        filter = Entity.id == id_or_slug
     else:
-        return db.execute(q.where(Entity.slug == id_or_slug)).scalar()
+        filter = Entity.slug == id_or_slug
+    e = db.execute(q.where(filter)).scalar()
+    if e is None:
+        raise MissingEntityException(obj_id=id_or_slug)
+    return e
 
 
 def get_entity(db: Session, id_or_slug: Union[int, str], schema: Schema) -> dict:
     e = get_entity_model(db=db, id_or_slug=id_or_slug, schema=schema)
-    
-    if e is None:
-        raise MissingEntityException(obj_id=id_or_slug)
-
     attrs = [i.attribute.name for i in schema.attr_defs]
     return _get_entity_data(db=db, entity=e, attr_names=attrs)
 


### PR DESCRIPTION
this commit attempts to fix #128 

### summary
`get_entity_model` now throws an exception instead of returning `None`. 

the `/backend/general_routes.py` and `/backend/dynamic_routes.py` (which calls `/backend/traceability/entity.py`'s `create_entity_delete_request` method), already implement the exception handling. 
<hr>
<details>
<summary> description from the previous commit </summary>
### summary

this commit replaces the `get_entity_model()` function with the `get_entity()` function in the `get_entity_changes()` route. the `get_entity()` function internally calls the `get_entity_model()` function and handles the case when it returns None. this avoids the `AttributeError` when accessing the `entity.id` attribute. 

### description
the issue reported an internal server error when requesting the changes for a non-existent entity. the error logs showed that the get_entity_model() function returned None when it could not find the matching model in the database. this caused an AttributeError when trying to access the entity.id attribute in the get_entity_changes() route.
```
File "/opt/aimaas/general_routes.py", line 237, in get_entity_changes
    return get_recent_entity_changes(db=db, entity_id=entity.id, params=params)
AttributeError: 'NoneType' object has no attribute 'id'
```

the get_entity() function was designed to handle this scenario. it calls the get_entity_model() function and checks if it returns None. if so, it raises a `MissingEntityException`. otherwise, it returns the output of `_get_entity_data()`.

i have explained further in the this comment: https://github.com/SUSE/aimaas/issues/128#issuecomment-1562345969

this is the current output demonstrating the fix:
clientside:
```
󱂕  curl http://localhost:8080/api/changes/entity/foo/does-not-exist
{"detail":"Entity with id does-not-exist doesn't exist or was deleted"}%
```
serverside:
```
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
...
INFO:     172.17.0.1:50478 - "GET /changes/entity/foo/does-not-exist HTTP/1.1" 404 Not Found
```
</details>