### PR TITLE
Removed version constraint of `pydantic`

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,9 @@
+from fastapi_pagination import add_pagination
+
 from . import create_app, models
 from .database import engine
 
 
 models.Base.metadata.create_all(engine)
 app = create_app()
+add_pagination(app)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,11 +1,10 @@
 alembic
 fastapi
-fastapi-pagination[sqlalchemy]
+fastapi-pagination[sqlalchemy]<0.12
 ldap3
 passlib[bcrypt]
 psycopg2-binary
-# See: https://github.com/samuelcolvin/pydantic/issues/4131
-pydantic<1.9.1
+pydantic<2
 python-dotenv
 python-jose[cryptography]
 python-multipart


### PR DESCRIPTION
The constraint was introduced in #74 due to https://github.com/pydantic/pydantic/issues/4131. The fix for pydantic has been released and the constraint is now superfluous.