### PR TITLE
Show attribute description tooltips

### DIFF
--- a/frontend/src/components/inputs/EntityForm.vue
+++ b/frontend/src/components/inputs/EntityForm.vue
@@ -9,10 +9,10 @@
       <template v-for="attr in schema?.attributes || []" :key="attr.name">
         <!-- ATTRIBUTE IS REFERENCE -->
         <template v-if="attr.type === 'FK'">
-            <ReferencedEntitySelect v-model="editEntity[attr.name]" :label="attr.name"
-                                    :args="{id: attr.name, tooltip: attr.description}" :fk-schema-id="attr.bound_schema_id"
-                                    :select-type="attr.list ? 'many': 'single'"
-                                    :required="requiredAttrs.includes(attr.name)" />
+          <ReferencedEntitySelect v-model="editEntity[attr.name]" :label="attr.name"
+                                  :args="{id: attr.name, tooltip: attr.description}" :fk-schema-id="attr.bound_schema_id"
+                                  :select-type="attr.list ? 'many': 'single'"
+                                  :required="requiredAttrs.includes(attr.name)" />
         </template>
         <!-- ATTRIBUTE IS SINGLE VALUED -->
         <template v-else-if="!attr.list">

--- a/frontend/src/components/inputs/EntityForm.vue
+++ b/frontend/src/components/inputs/EntityForm.vue
@@ -5,21 +5,20 @@
                  :required="true"/>
       <TextInput label="Slug" v-model="editEntity.slug" :args="{ id: 'slug', maxlength: 128 }"
                  :required="true"/>
-
       <h3 class="mt-3">Attributes</h3>
       <template v-for="attr in schema?.attributes || []" :key="attr.name">
         <!-- ATTRIBUTE IS REFERENCE -->
         <template v-if="attr.type === 'FK'">
-          <ReferencedEntitySelect v-model="editEntity[attr.name]" :label="attr.name"
-                                  :args="{id: attr.name}" :fk-schema-id="attr.bound_schema_id"
-                                  :select-type="attr.list ? 'many': 'single'"
-                                  :required="requiredAttrs.includes(attr.name)"/>
+            <ReferencedEntitySelect v-model="editEntity[attr.name]" :label="attr.name"
+                                    :args="{id: attr.name, tooltip: attr.description}" :fk-schema-id="attr.bound_schema_id"
+                                    :select-type="attr.list ? 'many': 'single'"
+                                    :required="requiredAttrs.includes(attr.name)" />
         </template>
         <!-- ATTRIBUTE IS SINGLE VALUED -->
         <template v-else-if="!attr.list">
           <component :is="TYPE_INPUT_MAP[attr.type]" v-model="editEntity[attr.name]"
-                     :label="attr.name" :args="{id: attr.name}"
-                     :required="requiredAttrs.includes(attr.name)"/>
+                    :label="attr.name" :args="{id: attr.name, tooltip: attr.description}"
+                    :required="requiredAttrs.includes(attr.name)" />
         </template>
         <!-- ATTRIBUTE IS MULTI VALUED -->
         <template v-else>
@@ -34,8 +33,8 @@
                     class="list-group-item d-flex">
                   <div class="flex-grow-1">
                     <component :is="TYPE_INPUT_MAP[attr.type]" v-model="editEntity[attr.name][idx]"
-                               :vertical="true" :args="{id: `${attr.name}-${idx}`}"
-                               :required="requiredAttrs.includes(attr.name)"/>
+                              :vertical="true" :args="{id: `${attr.name}-${idx}`, tooltip: attr.description}"
+                              :required="requiredAttrs.includes(attr.name)"/>
                   </div>
                   <div>
                     <button type="button" class="btn btn-outline-cta ms-1"

--- a/frontend/src/components/layout/BaseInput.vue
+++ b/frontend/src/components/layout/BaseInput.vue
@@ -1,10 +1,11 @@
 <template>
   <div :class="classes" data-bs-toggle="tooltip"
        :title="args.tooltip">
-    <label :for="args.id" :class="labelClass" v-if="label" data-bs-toggle="tooltip"
-           :title="required ? 'This value is required': ''">
+    <label :for="args.id" :class="labelClass" v-if="label" >
       <slot name="label">
-        {{ label }} <sup v-if="required" class="text-danger">*</sup>
+        {{ label }}
+        <sup v-if="required" class="text-danger" data-bs-toggle="tooltip"
+             title="This value is required">*</sup>
       </slot>
     </label>
     <div :class="columns">


### PR DESCRIPTION
This pull request introduces an enhancement related to tooltips. Now, when you hover over an attribute or its corresponding input field within the entity details page, or when you hover over an attribute in the table header while viewing the entity table list, a tooltip will appear, displaying the attribute's 'description'.

see: #71 