### PR TITLE
Support recovery of deleted entities (fixes #88)

### DIFF
--- a/backend/alembic/versions/5e46d4ff6f21_change_type.py
+++ b/backend/alembic/versions/5e46d4ff6f21_change_type.py
@@ -1,0 +1,24 @@
+"""ChangeType for restoring deleted items
+
+Revision ID: 5e46d4ff6f21
+Revises: 8a3f36ffa8df
+Create Date: 2023-09-25 15:28:13.752183
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5e46d4ff6f21'
+down_revision = '8a3f36ffa8df'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE changetype ADD VALUE IF NOT EXISTS 'RESTORE'")
+
+
+def downgrade():
+    pass

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -88,9 +88,12 @@ def get_schema(db: Session, id_or_slug: Union[int, str]) -> Schema:
 
 def _check_bound_schema_id(db: Session, schema_id: int):
     try:
-        db.query(Schema.id).filter(Schema.id == schema_id, Schema.deleted == False).one()
+        schema = db.query(Schema).filter(Schema.id == schema_id).one()
     except NoResultFound:
         raise MissingSchemaException(obj_id=schema_id)
+
+    if schema.deleted:
+        raise SchemaIsDeletedException(obj_id=schema_id)
 
 
 def create_schema(db: Session, data: SchemaCreateSchema, commit: bool = True) -> Schema:
@@ -143,7 +146,7 @@ def create_schema(db: Session, data: SchemaCreateSchema, commit: bool = True) ->
 
 
 def delete_schema(db: Session, id_or_slug: Union[int, str], commit: bool = True) -> Schema:
-    q = select(Schema).where(Schema.deleted == False)
+    q = select(Schema)
     if isinstance(id_or_slug, int):
         q = q.where(Schema.id == id_or_slug)
     else:
@@ -152,6 +155,8 @@ def delete_schema(db: Session, id_or_slug: Union[int, str], commit: bool = True)
     schema = db.execute(q).scalar()
     if schema is None:
         raise MissingSchemaException(obj_id=id_or_slug)
+    if schema.deleted:
+        raise NoOpChangeException(f"Schema with id {schema.id} is already deleted")
     
     db.execute(update(Entity)
                .where(Entity.schema_id == schema.id, Entity.deleted == False)
@@ -650,8 +655,7 @@ def update_entity(db: Session, id_or_slug: Union[str, int], schema_id: int, data
     if e.schema.deleted:
         raise MissingSchemaException(obj_id=e.schema.id)
     if e.deleted:
-        # Updating a deleted entity implies its restoration.
-        e.deleted = False
+        raise EntityIsDeletedException(obj_id=e.id)
     
     slug = data.pop('slug', e.slug)
     name = data.pop('name', e.name)
@@ -719,7 +723,7 @@ def update_entity(db: Session, id_or_slug: Union[str, int], schema_id: int, data
 
 
 def delete_entity(db: Session, id_or_slug: Union[int, str], schema_id: int, commit: bool = True) -> Entity:
-    q = select(Entity).where(Entity.deleted == False).where(Entity.schema_id == schema_id)
+    q = select(Entity).where(Entity.schema_id == schema_id)
     if isinstance(id_or_slug, int):
         q = q.where(Entity.id == id_or_slug)
     else:
@@ -727,6 +731,8 @@ def delete_entity(db: Session, id_or_slug: Union[int, str], schema_id: int, comm
     e = db.execute(q).scalar()
     if e is None:
         raise MissingEntityException(obj_id=id_or_slug)
+    if e.deleted:
+        raise NoOpChangeException(f"Entity with id {e.id} is already deleted")
     e.deleted = True
     if commit:
         db.commit()
@@ -736,7 +742,7 @@ def delete_entity(db: Session, id_or_slug: Union[int, str], schema_id: int, comm
 
 
 def restore_entity(db: Session, id_or_slug: Union[int, str], schema_id: int, commit: bool = True) -> Entity:
-    q = select(Entity).where(Entity.schema_id == schema_id).where(Entity.deleted == True)
+    q = select(Entity).where(Entity.schema_id == schema_id)
     if isinstance(id_or_slug, int):
         q = q.where(Entity.id == id_or_slug)
     else:
@@ -744,6 +750,8 @@ def restore_entity(db: Session, id_or_slug: Union[int, str], schema_id: int, com
     e = db.execute(q).scalar()
     if e is None:
         raise MissingEntityException(obj_id=id_or_slug)
+    if not e.deleted:
+        raise NoOpChangeException(f"Entity with id {e.id} is not deleted")
     e.deleted = False
     if commit:
         db.commit()

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -27,7 +27,7 @@ class GroupExistsException(Exception):
         return f'Group with name {self.name} already exists'
 
 
-class MissingObjectException(Exception):
+class ObjectException(Exception):
     obj_type: str = "Object"
 
     def __init__(self, obj_id: Union[int, str], obj_type: Optional[str] = None):
@@ -35,13 +35,34 @@ class MissingObjectException(Exception):
         self.obj_type = obj_type or self.obj_type
 
     def __str__(self) -> str:
-        return f"{self.obj_type} with id {self.obj_id} doesn't exist or was deleted"
+        raise NotImplementedError("Define in subclasses")
+
+
+class MissingObjectException(ObjectException):
+    def __str__(self) -> str:
+        return f"{self.obj_type} with id {self.obj_id} doesn't exist"
+
+
+class DeletedObjectException(ObjectException):
+    def __str__(self):
+        return f"{self.obj_type} with id {self.obj_id} is deleted"
+
 
 class MissingSchemaException(MissingObjectException):
     obj_type = 'Schema'
 
+
+class SchemaIsDeletedException(DeletedObjectException):
+    obj_type = 'Schema'
+
+
 class MissingEntityException(MissingObjectException):
     obj_type = 'Entity'
+
+
+class EntityIsDeletedException(DeletedObjectException):
+    obj_type = 'Entity'
+
 
 class MissingAttributeException(MissingObjectException):
     obj_type = 'Attribute'

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -65,6 +65,11 @@ class MissingEntityDeleteRequestException(MissingObjectException):
         return f'There is no entity delete request with id {self.obj_id}'
 
 
+class MissingEntityRestoreRequestException(MissingObjectException):
+    def __str__(self) -> str:
+        return f'There is no entity restore request with id {self.obj_id}'
+
+
 class MissingEntityCreateRequestException(MissingObjectException):
     def __str__(self) -> str:
         return f'There is no entity create request with id {self.obj_id}'

--- a/backend/general_routes.py
+++ b/backend/general_routes.py
@@ -182,7 +182,7 @@ def update_schema(
     summary="Delete schema",
     responses={
         200: {"description": "Schema was deleted"},
-        208: {"description": "Schema was already deleted"},
+        208: {"description": "Schema is already deleted"},
         404: {"description": "Schema does not exist"},
     }
 )

--- a/backend/tests/test_crud_schema.py
+++ b/backend/tests/test_crud_schema.py
@@ -7,7 +7,7 @@ from ..crud import create_schema, get_schema, get_schemas, update_schema, delete
     get_entities, update_entity, get_entity
 from ..exceptions import SchemaExistsException, MissingSchemaException, RequiredFieldException, \
     NoOpChangeException, ListedToUnlistedException, MultipleAttributeOccurencesException, \
-    InvalidAttributeChange
+    InvalidAttributeChange, SchemaIsDeletedException
 from ..models import Schema, AttributeDefinition, Attribute, AttrType, Entity
 from .. schemas import AttrDefSchema, SchemaCreateSchema, AttrTypeMapping, SchemaUpdateSchema
 
@@ -151,7 +151,7 @@ class TestSchemaCreate(DefaultMixin):
         )
        
         sch = SchemaCreateSchema(name='Test', slug='test', attributes=[attr_def])
-        with pytest.raises(MissingSchemaException):
+        with pytest.raises(SchemaIsDeletedException):
             create_schema(dbsession, data=sch)
 
     def test_raise_on_multiple_attrs_with_same_name(self, dbsession):
@@ -656,7 +656,7 @@ class TestSchemaDelete(DefaultMixin):
         schema = self.get_default_schema(dbsession)
         schema.deleted = True
         dbsession.flush()
-        with pytest.raises(MissingSchemaException):
+        with pytest.raises(NoOpChangeException):
             delete_schema(dbsession, id_or_slug=schema.id)
 
     def test_raise_on_delete_nonexistent(self, dbsession):

--- a/backend/tests/test_dynamic_routes.py
+++ b/backend/tests/test_dynamic_routes.py
@@ -541,6 +541,8 @@ class TestRouteDeleteEntity(DefaultMixin):
         response = authorized_client.delete(f'/entity/person/{entity.slug}?restore=1')
         assert response.status_code == 200
         assert response.json() == {'id': entity.id, 'slug': 'Jack', 'name': 'Jack', 'deleted': False}
+        dbsession.refresh(entity)
+        assert entity.deleted is False
 
     def test_restore_on_nondeleted(self, dbsession, authorized_client):
         entity = self.get_default_entity(dbsession)

--- a/backend/tests/test_general_routes.py
+++ b/backend/tests/test_general_routes.py
@@ -52,7 +52,7 @@ class TestRouteAttributes(DefaultMixin):
     def test_raise_on_attribute_doesnt_exist(self, dbsession: Session, client: TestClient):
         response = client.get('/attributes/123456789')
         assert response.status_code == 404
-        assert "doesn't exist or was deleted" in response.json()['detail']
+        assert "doesn't exist" in response.json()['detail']
 
 
 class TestRouteSchemasGet(DefaultMixin):
@@ -171,11 +171,11 @@ class TestRouteSchemasGet(DefaultMixin):
     def test_raise_on_schema_doesnt_exist(self, dbsession, client):
         response = client.get('/schema/12345678')
         assert response.status_code == 404
-        assert "doesn't exist or was deleted" in response.json()['detail']
+        assert "doesn't exist" in response.json()['detail']
 
         response = client.get('/schema/qwertyui')
         assert response.status_code == 404
-        assert "doesn't exist or was deleted" in response.json()['detail']
+        assert "doesn't exist" in response.json()['detail']
 
 
 class TestRouteSchemaCreate(DefaultMixin):
@@ -287,7 +287,7 @@ class TestRouteSchemaCreate(DefaultMixin):
         } 
         response = authorized_client.post('/schema', json=data)
         assert response.status_code == 404
-        assert "doesn't exist or was deleted" in response.json()['detail']
+        assert "doesn't exist" in response.json()['detail']
 
     def test_raise_on_passed_deleted_schema_for_binding(self, dbsession: Session, authorized_client: TestClient):
         schema = self.get_default_schema(dbsession)
@@ -309,8 +309,8 @@ class TestRouteSchemaCreate(DefaultMixin):
             ]
         } 
         response = authorized_client.post('/schema', json=data)
-        assert response.status_code == 404
-        assert "doesn't exist or was deleted" in response.json()['detail']
+        assert response.status_code == 410
+        assert "is deleted" in response.json()['detail']
 
     def test_raise_on_multiple_attrs_with_same_name(self, dbsession: Session, authorized_client: TestClient):
         data = {
@@ -411,7 +411,7 @@ class TestRouteSchemaUpdate(DefaultMixin):
         }
         response = authorized_client.put('/schema/12345678', json=data)
         assert response.status_code == 404
-        assert "doesn't exist or was deleted" in response.json()['detail']
+        assert "doesn't exist" in response.json()['detail']
 
     def test_raise_on_existing_slug_or_name(self, dbsession: Session, authorized_client: TestClient):
         new_sch = Schema(name='Test', slug='test')
@@ -489,7 +489,7 @@ class TestRouteSchemaUpdate(DefaultMixin):
         schema = self.get_default_schema(dbsession)
         response = authorized_client.put(f'/schema/{schema.id}', json=data)
         assert response.status_code == 404
-        assert "doesn't exist or was deleted" in response.json()['detail']
+        assert "doesn't exist" in response.json()['detail']
 
     def test_raise_on_schema_not_passed_when_binding(self, dbsession: Session, authorized_client: TestClient):
         data = {
@@ -578,7 +578,7 @@ class TestRouteSchemaDelete(DefaultMixin):
         schema.deleted = True
         dbsession.commit()
         response = authorized_client.delete(f'/schema/{schema.id}')
-        assert response.status_code == 404
+        assert response.status_code == 208
 
     @pytest.mark.parametrize('id_or_slug', [1234567, 'qwerty'])
     def test_raise_on_delete_nonexistent(self, dbsession, authorized_client, id_or_slug):

--- a/backend/traceability/enum.py
+++ b/backend/traceability/enum.py
@@ -28,3 +28,4 @@ class ChangeType(enum.Enum):
     CREATE = 'CREATE'
     UPDATE = 'UPDATE'
     DELETE = 'DELETE'
+    RESTORE = 'RESTORE'

--- a/frontend/src/components/EntityList.vue
+++ b/frontend/src/components/EntityList.vue
@@ -1,5 +1,6 @@
 <template>
   <SearchPanel
+      ref="searchpanel"
       @search="setFiltersAndSearch"
       :key="schema?.slug"
       :schema="schema"
@@ -22,10 +23,19 @@
             {{numSelected}} {{ entityPluralized }} selected
           </small>
           <ConfirmButton :callback="onDeletion"
-                         btn-class="btn-outline-danger">
+                         btn-class="btn-outline-danger"
+                         v-if="$refs?.searchpanel?.listMode !== 'deleted'">
             <template v-slot:label>
               <i class="eos-icons me-1">delete</i>
               <span>Delete</span>
+            </template>
+          </ConfirmButton>
+          <ConfirmButton :callback="onRestoration"
+                         btn-class="btn-outline-danger"
+                         v-if="$refs?.searchpanel?.listMode !== 'active'">
+            <template v-slot:label>
+              <i class="eos-icons me-1">restore_from_trash</i>
+              <span>Restore</span>
             </template>
           </ConfirmButton>
           <RouterLink class="btn btn-outline-primary"
@@ -145,6 +155,15 @@ export default {
     onDeletion() {
       const promises = this.selected.map(eId => {
         this.$api.deleteEntity({
+          schemaSlug: this.schema.slug,
+          entityIdOrSlug: eId
+        });
+      });
+      Promise.all(promises).then(() => this.getEntities({resetPage: true}));
+    },
+    onRestoration() {
+      const promises = this.selected.map(eId => {
+        this.$api.restoreEntity({
           schemaSlug: this.schema.slug,
           entityIdOrSlug: eId
         });

--- a/frontend/src/components/EntityList.vue
+++ b/frontend/src/components/EntityList.vue
@@ -30,6 +30,7 @@
               <span>Delete</span>
             </template>
           </ConfirmButton>
+          <!-- Remember: Deleted entities can be included in modes 'deleted' and 'all' 😉 -->
           <ConfirmButton :callback="onRestoration"
                          btn-class="btn-outline-primary"
                          v-if="$refs?.searchpanel?.listMode !== 'active'">

--- a/frontend/src/components/EntityList.vue
+++ b/frontend/src/components/EntityList.vue
@@ -31,7 +31,7 @@
             </template>
           </ConfirmButton>
           <ConfirmButton :callback="onRestoration"
-                         btn-class="btn-outline-danger"
+                         btn-class="btn-outline-primary"
                          v-if="$refs?.searchpanel?.listMode !== 'active'">
             <template v-slot:label>
               <i class="eos-icons me-1">restore_from_trash</i>

--- a/frontend/src/components/EntityListTable.vue
+++ b/frontend/src/components/EntityListTable.vue
@@ -22,8 +22,7 @@
       <tr v-for="e in entities" :key="e.id" :class="{'table-light': e.deleted}">
         <td v-if="showSelectors">
           <input :type="inputType" class="form-check-input" name="EntitySelection" :value="e.id"
-                 @change="$emit('select')" :checked="selected.includes(e.id)"
-                 :disabled="e.deleted"/>
+                 @change="$emit('select')" :checked="selected.includes(e.id)" />
         </td>
         <td v-for="field in displayFieldsWithDescriptions" :key="field.name">
           <template v-if="field.name === 'name'">

--- a/frontend/src/components/inputs/EntityForm.vue
+++ b/frontend/src/components/inputs/EntityForm.vue
@@ -56,8 +56,18 @@
           </div>
         </template>
       </template>
-      <div class="d-grid gap-2 mt-1">
-        <button type="button" class="btn btn-primary p-2" @click="saveChanges">
+      <div class="d-flex gap-2 mt-1">
+        <button v-if="entity?.id && !entity?.deleted" type="button" class="btn btn-danger p-2"
+                @click="deleteEntity">
+          <i class="eos-icons me-1">delete</i>
+          Delete
+        </button>
+        <button v-if="entity?.id && entity?.deleted" type="button" class="btn btn-primary p-2"
+                @click="restoreEntity">
+          <i class="eos-icons me-1">restore_from_trash</i>
+          Restore
+        </button>
+        <button type="button" class="btn btn-primary p-2 flex-grow-1" @click="saveChanges">
           <i class="eos-icons me-1">save</i>
           Save {{ batchMode? 'all changes' : 'changes'}}
         </button>
@@ -231,7 +241,26 @@ export default {
       if (response) {
         this.updatePendingRequests();
       }
+      this.$emit("update");
     },
+    async deleteEntity() {
+      if (this.entity?.id) {
+        await this.$api.deleteEntity({
+          schemaSlug: this.schema.slug,
+          entityIdOrSlug: this.entity.id
+        });
+        this.$emit("update");
+      }
+    },
+    async restoreEntity() {
+      if (this.entity?.id) {
+        await this.$api.restoreEntity({
+          schemaSlug: this.schema.slug,
+          entityIdOrSlug: this.entity.id
+        });
+        this.$emit("update");
+      }
+    }
   },
 }
 </script>

--- a/frontend/src/plugins/api.js
+++ b/frontend/src/plugins/api.js
@@ -247,6 +247,18 @@ class API {
         return response;
     }
 
+
+    async restoreEntity({schemaSlug, entityIdOrSlug} = {}){
+        const response = await this._fetch({
+            url: `${this.base}/entity/${schemaSlug}/${entityIdOrSlug}?restore=1`,
+            method: 'DELETE'
+        });
+        if (response !== null) {
+            this.alerts.push("success", `Entity restored: ${response.name}`);
+        }
+        return response;
+    }
+
     async getChangeRequests({page = 1, size = 10, schemaSlug, entityIdOrSlug} = {}) {
         const params = new URLSearchParams();
         params.set('page', page);

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -51,6 +51,7 @@ export const CHANGE_STATUS_MAP = {
     APPROVED: 'success',
     add: 'add',
     create: 'add',
-    delete: 'remove',
-    update: 'mode_edit'
+    delete: 'delete',
+    update: 'mode_edit',
+    restore: 'restore_from_trash'
 }


### PR DESCRIPTION
This commit adds an explicit way to restore deleted entities and an implicit way (i.e. an entity gets un-deleted when changes are posted).

Closes #88.