### PR TITLE
Fixed issue with incorrect 404 message when following foreign key link

### DIFF
--- a/frontend/src/components/Entity.vue
+++ b/frontend/src/components/Entity.vue
@@ -81,9 +81,9 @@ export default {
   },
   methods: {
     async updateEntity() {
-      if (this.$route.params.entitySlug && this.activeSchema) {
+      if (this.$route.params.entitySlug && this.$route.params.schemaSlug) {
         const params = {
-          schemaSlug: this.activeSchema.slug,
+          schemaSlug: this.$route.params.schemaSlug,
           entityIdOrSlug: this.$route.params.entitySlug
         };
         this.entity = await this.$api.getEntity(params);
@@ -107,9 +107,6 @@ export default {
     async "$route.params.entitySlug"() {
       await this.updateEntity();
     },
-    async activeSchema() {
-      await this.updateEntity();
-    }
   }
 };
 </script>


### PR DESCRIPTION
When following a link to an entity, it can happen that the API request to get the entity details is sent before the injected property `activeSchema` is updated. This means that the request used the wrong URL.

With this fix, the schema slug is used directly from the current route parameters.

Fixes #158.