### PR TITLE
Remove redundant todo placeholder

### DIFF
--- a/frontend/src/components/layout/Placeholder.vue
+++ b/frontend/src/components/layout/Placeholder.vue
@@ -15,9 +15,7 @@
       <span v-else class="placeholder col-8"></span>
     </slot>
   </div>
-  <slot v-else name="content">
-    <p class="alert alert-warning">TODO: Add your content into this slot</p>
-  </slot>
+  <slot v-else name="content"/>
 </template>
 
 <script>


### PR DESCRIPTION
There is no place which the code fallback to render the removed <p/> (except RefEntity.vue, which is not desired). That's why I decided to directly remove it. Correct me if we want to keep this.