### PR TITLE
Refresh entity detail and schema detail on update

### DIFF
--- a/frontend/src/components/EntityList.vue
+++ b/frontend/src/components/EntityList.vue
@@ -75,6 +75,9 @@ export default {
       default: false
     }
   },
+  activated() {
+    this.getEntities({resetPage: false});
+  },
   computed: {
     pages: computed(() => {
       try {

--- a/frontend/src/components/inputs/ReferencedEntitySelect.vue
+++ b/frontend/src/components/inputs/ReferencedEntitySelect.vue
@@ -125,6 +125,10 @@ export default {
   watch: {
     modelValue() {
       this.getSelected();
+    },
+    selected: {
+      handler: "getSelected",
+      immediate: true
     }
   }
 };


### PR DESCRIPTION
Related to https://github.com/SUSE/aimaas/issues/178

Applied fixes for:

1. When you edit an entity/attributes in entity detail page and you click save, the values of attributes of type FK are vanishing. Previously manual page reload showed them again and now it's not needed.

2. If you go back from entity detail page to schema details, entity list is not refreshed. Now it is.