### PR TITLE
Update entity list when needed

### DIFF
--- a/frontend/src/components/EntityList.vue
+++ b/frontend/src/components/EntityList.vue
@@ -51,12 +51,13 @@
 </template>
 
 <script>
-import {computed} from "vue";
+import {computed, watch} from "vue";
 
 import ConfirmButton from "@/components/inputs/ConfirmButton";
 import Pagination from "./layout/Pagination.vue";
 import EntityListTable from "@/components/EntityListTable";
 import SearchPanel from "./SearchPanel.vue";
+import {updateEntityListCount} from "@/store";
 
 export default {
   components: {EntityListTable, Pagination, SearchPanel, ConfirmButton},
@@ -75,8 +76,8 @@ export default {
       default: false
     }
   },
-  activated() {
-    this.getEntities({resetPage: false});
+  created() {
+    watch(updateEntityListCount, (async () => await this.getEntities({resetPage: false})));
   },
   computed: {
     pages: computed(() => {

--- a/frontend/src/components/inputs/EntityForm.vue
+++ b/frontend/src/components/inputs/EntityForm.vue
@@ -228,8 +228,6 @@ export default {
         body: this.editEntity
       });
       this.loading = false;
-      updateEntityList();
-
       return response;
     },
     async saveEntity() {
@@ -244,6 +242,7 @@ export default {
       }
       if (response) {
         this.updatePendingRequests();
+        updateEntityList();
       }
       this.$emit("update");
     },

--- a/frontend/src/components/inputs/EntityForm.vue
+++ b/frontend/src/components/inputs/EntityForm.vue
@@ -90,6 +90,7 @@ import FloatInput from "@/components/inputs/FloatInput";
 import ReferencedEntitySelect from "@/components/inputs/ReferencedEntitySelect";
 import Spinner from "@/components/layout/Spinner";
 import {TYPE_INPUT_MAP} from "@/utils";
+import {updateEntityList} from "@/store";
 
 
 export default {
@@ -227,6 +228,8 @@ export default {
         body: this.editEntity
       });
       this.loading = false;
+      updateEntityList();
+
       return response;
     },
     async saveEntity() {

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,0 +1,4 @@
+import {ref} from 'vue';
+
+export const updateEntityListCount = ref(0);
+export const updateEntityList = () => updateEntityListCount.value++;


### PR DESCRIPTION
Working on the aimaas frontend in the last days made me think about that we are only doing parent-to-child and child-to-parent data flows (and actually this seems okay in the most of the cases).   

Back in the days before, in another company, we've used a global event bus to transmit events between components. This is now removed in Vue 3 and there is only the ability to transmit events between a parent and a child component, because the global event bus is considered as anti-pattern. I can understand why, I think the abusing it could lead to very unexpected behaviour and bugs which are hard to debug. I see that there are solutions out there like pinia, vuex... but I'm not sure if we want to invest in this at that point.

In one of my previous MRs I've included the ability to refresh the entity list table whenever visible by activated hook. Of course, this solution is not ideal, maybe we would like to refresh it on route change and when something is updated/created. In the last [MR](https://github.com/SUSE/aimaas/pull/192), since we removed the global keep-alive component, the activate hook in entity list is causing unnecessary reloads and can be removed. However, I've noticed that when we switch from entity list to entity create tab, create a new entity and return back to the entity list, the list is not reloaded. This MR introduces a simple solution without 3rd party libraries. 

What do you think about this solution?