### PR TITLE
Fix DateTime attribute field value does not get rendered on Entity edit

### DIFF
--- a/frontend/src/components/inputs/DateTime.vue
+++ b/frontend/src/components/inputs/DateTime.vue
@@ -2,7 +2,7 @@
   <BaseInput :label="label" :args="args" :vertical="vertical" :required="required">
     <template v-slot:field>
       <input class="form-control" type="datetime-local"
-             :value="modelValue && convertToDateTimeLocalString(modelValue)"
+             :value="value"
              @input="onInput"
              v-bind="args"/>
     </template>
@@ -16,6 +16,11 @@ export default {
   name: "DateTime",
   components: {BaseInput},
   props: ["label", "modelValue", "args", "vertical", "required"],
+  computed: {
+    value() {
+      return this.modelValue && this.convertToDateTimeLocalString(this.modelValue);
+    }
+  },
   methods: {
     onInput(event) {
       this.$emit("update:modelValue", event.target.value);

--- a/frontend/src/components/inputs/DateTime.vue
+++ b/frontend/src/components/inputs/DateTime.vue
@@ -1,7 +1,9 @@
 <template>
   <BaseInput :label="label" :args="args" :vertical="vertical" :required="required">
     <template v-slot:field>
-      <input class="form-control" type="datetime-local" :value="modelValue" @input="onInput"
+      <input class="form-control" type="datetime-local"
+             :value="modelValue && convertToDateTimeLocalString(modelValue)"
+             @input="onInput"
              v-bind="args"/>
     </template>
   </BaseInput>
@@ -18,6 +20,19 @@ export default {
     onInput(event) {
       this.$emit("update:modelValue", event.target.value);
     },
+    convertToDateTimeLocalString(date) {
+      if (!(date instanceof Date)) {
+        date = new Date(date)
+      }
+
+      const year = date.getFullYear();
+      const month = (date.getMonth() + 1).toString().padStart(2, "0");
+      const day = date.getDate().toString().padStart(2, "0");
+      const hours = date.getHours().toString().padStart(2, "0");
+      const minutes = date.getMinutes().toString().padStart(2, "0");
+
+      return `${year}-${month}-${day}T${hours}:${minutes}:00`;
+    }
   },
 };
 </script>

--- a/frontend/src/components/inputs/DateTime.vue
+++ b/frontend/src/components/inputs/DateTime.vue
@@ -30,13 +30,7 @@ export default {
         date = new Date(date)
       }
 
-      const year = date.getFullYear();
-      const month = (date.getMonth() + 1).toString().padStart(2, "0");
-      const day = date.getDate().toString().padStart(2, "0");
-      const hours = date.getHours().toString().padStart(2, "0");
-      const minutes = date.getMinutes().toString().padStart(2, "0");
-
-      return `${year}-${month}-${day}T${hours}:${minutes}:00`;
+      return date.toISOString().substring(0, 16);
     }
   },
 };


### PR DESCRIPTION
When there is a value returned from the server for datetime attribute, on Entity detail page the DateTime component does not render it due to wrong format.